### PR TITLE
[FEAT] 로그인, 토큰 재발급 로직 확장성 확장

### DIFF
--- a/src/main/java/com/macrosoft/modakserver/domain/member/controller/AuthController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/controller/AuthController.java
@@ -22,22 +22,22 @@ public class AuthController {
     private final AuthService authService;
 
     @Operation(summary = "애플 소셜 로그인", description = "로그인을 하고 `Access Token` 과 `Refresh Token` 을 발급합니다. Apple 로부터 받은 UserId 를 SHA256으로 해시해서 `encryptedUserIdentifier` 로 보내주세요. 나머지 정보는 아직 사용하지 않습니다.")
-    @PostMapping("/login/apple")
+    @PostMapping("/login")
     public BaseResponse<MemberResponse.MemberLogin> signIn(
             @RequestBody MemberRequest.MemberSignIn request) {
 
         return BaseResponse.onSuccess(authService.login(
-                SocialType.APPLE,
+                request.getSocialType(),
                 request.getAuthorizationCode(),
                 request.getIdentityToken(),
                 request.getEncryptedUserIdentifier()));
     }
 
     @PostMapping("/refresh-access-token")
-    @Operation(summary = "Access Token 재발급", description = "로그인을 하고 `Access Token` 과 `Refresh Token` 을 발급합니다. Apple 로부터 받은 UserId 를 SHA256으로 해시해서 `encryptedUserIdentifier` 로 보내주세요. 나머지 정보는 아직 사용하지 않습니다.")
+    @Operation(summary = "Access Token 재발급", description = "`Access Token` 이 만료됐을 경우 호출해 주세요. `Refresh Token` 과 `EncryptedUserIdentifier` 로 `Access Token` 을 재발급합니다.")
     public BaseResponse<MemberResponse.accessToken> refreshAccessToken(
             @RequestBody MemberRequest.RefreshTokenRequest request) {
 
-        return BaseResponse.onSuccess(authService.refreshAccessToken(request.getEncryptedUserIdentifier(), request.getRefreshToken()));
+        return BaseResponse.onSuccess(authService.refreshAccessToken(request.getSocialType(), request.getEncryptedUserIdentifier(), request.getRefreshToken()));
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/controller/MemberController.java
@@ -19,18 +19,18 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @Operation(summary = "회원 정보 가져오기", description = "회원의 정보를 가져옵니다.")
+    @Operation(summary = "회원 닉네임 가져오기", description = "회원의 닉네임을 가져옵니다.")
     @GetMapping("/nickname")
-    public BaseResponse<MemberResponse.MemberInfo> getMemberInfo(
+    public BaseResponse<MemberResponse.MemberNickname> getMemberNickname(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         Member member = userDetails.getMember();
-        return BaseResponse.onSuccess(memberService.getMemberInfo(member));
+        return BaseResponse.onSuccess(memberService.getMemberNickname(member));
     }
 
     @Operation(summary = "회원 닉네임 변경", description = "회원의 닉네임을 변경합니다.")
     @PatchMapping("/nickname")
-    public BaseResponse<MemberResponse.MemberInfo> updateNickname(
+    public BaseResponse<MemberResponse.MemberNickname> updateNickname(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam String nickname) {
 

--- a/src/main/java/com/macrosoft/modakserver/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/dto/MemberRequest.java
@@ -1,5 +1,6 @@
 package com.macrosoft.modakserver.domain.member.dto;
 
+import com.macrosoft.modakserver.domain.member.entity.SocialType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -10,6 +11,9 @@ public class MemberRequest {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class MemberSignIn {
+        @Schema(description = "소셜 로그인 타입", defaultValue = "APPLE")
+        private SocialType socialType;
+
         @Schema(description = "애플로부터 받은 Authorization Code", defaultValue = "c19074541137c4508ad5ab04301028c28.0.rrwuz.9laqvPNEVlUKyJ7AY-QeLw")
         private String authorizationCode;
 
@@ -31,7 +35,13 @@ public class MemberRequest {
 
     @Data
     public static class RefreshTokenRequest {
+        @Schema(description = "소셜 로그인 타입", defaultValue = "APPLE")
+        private SocialType socialType;
+
+        @Schema(description = "암호화 된 UserIdentifier", defaultValue = "614c0236d8480a64d9f2214e2486317de1ede78dc59250c806650bce3cbf6ed9")
         private String encryptedUserIdentifier;
+
+        @Schema(description = "Refresh Token", defaultValue = "refreshToken")
         private String refreshToken;
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/dto/MemberResponse.java
@@ -18,7 +18,7 @@ public class MemberResponse {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class MemberInfo {
+    public static class MemberNickname {
         private Long memberId;
         private String nickname;
     }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/entity/SocialType.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/entity/SocialType.java
@@ -1,5 +1,10 @@
 package com.macrosoft.modakserver.domain.member.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum SocialType {
     APPLE,
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/AuthService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/AuthService.java
@@ -6,5 +6,5 @@ import com.macrosoft.modakserver.domain.member.entity.SocialType;
 
 public interface AuthService {
     MemberResponse.MemberLogin login(SocialType socialType, String authorizationCode, String identityToken, String encryptedUserIdentifier);
-    MemberResponse.accessToken refreshAccessToken(String encryptedUserIdentifier, String refreshToken);
+    MemberResponse.accessToken refreshAccessToken(SocialType socialType, String encryptedUserIdentifier, String refreshToken);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/AuthServiceImpl.java
@@ -81,7 +81,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public MemberResponse.accessToken refreshAccessToken(String encryptedUserIdentifier, String refreshToken) {
+    public MemberResponse.accessToken refreshAccessToken(SocialType socialType, String encryptedUserIdentifier, String refreshToken) {
         // Refresh Token 검증
         jwtUtil.validateRefreshToken(refreshToken);
 

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberService.java
@@ -1,10 +1,9 @@
 package com.macrosoft.modakserver.domain.member.service;
 
-import com.macrosoft.modakserver.domain.member.dto.MemberResponse;
+import com.macrosoft.modakserver.domain.member.dto.MemberResponse.MemberNickname;
 import com.macrosoft.modakserver.domain.member.entity.Member;
-import com.macrosoft.modakserver.domain.member.entity.SocialType;
 
 public interface MemberService {
-    MemberResponse.MemberInfo getMemberInfo(Member member);
-    MemberResponse.MemberInfo updateNickname(Member member, String nickname);
+    MemberNickname getMemberNickname(Member member);
+    MemberNickname updateNickname(Member member, String nickname);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberServiceImpl.java
@@ -1,9 +1,7 @@
 package com.macrosoft.modakserver.domain.member.service;
 
-import com.macrosoft.modakserver.domain.member.dto.MemberResponse;
-import com.macrosoft.modakserver.domain.member.dto.MemberResponse.MemberInfo;
+import com.macrosoft.modakserver.domain.member.dto.MemberResponse.MemberNickname;
 import com.macrosoft.modakserver.domain.member.entity.Member;
-import com.macrosoft.modakserver.domain.member.entity.SocialType;
 import com.macrosoft.modakserver.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,8 +14,8 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
 
     @Override
-    public MemberInfo getMemberInfo(Member member) {
-        return MemberInfo.builder()
+    public MemberNickname getMemberNickname(Member member) {
+        return MemberNickname.builder()
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .build();
@@ -25,10 +23,10 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public MemberInfo updateNickname(Member member, String nickname) {
+    public MemberNickname updateNickname(Member member, String nickname) {
         member.setNickname(nickname);
         memberRepository.save(member);
-        return MemberInfo.builder()
+        return MemberNickname.builder()
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .build();


### PR DESCRIPTION
<!-- 제목 예시 -->
<!-- [FEAT/#6] 설명 -->
## 📝 작업 내용

- 로그인, 토큰 재발급 로직 확장성 확장

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
### 설명

로그인, 토큰 재발급 로직 을 나중에 다른 소셜 로그인이 붙어도 사용 가능하도록 했습니다

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성하거나 커멘트로 남겨주세요
 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
