### PR TITLE
[FEAT] 회원 탈퇴 시 개인 장작 정보 삭제

### DIFF
--- a/src/main/java/com/macrosoft/modakserver/domain/log/repository/PrivateLogRepository.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/repository/PrivateLogRepository.java
@@ -4,4 +4,5 @@ import com.macrosoft.modakserver.domain.log.entity.PrivateLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PrivateLogRepository extends JpaRepository<PrivateLog, Long> {
+    int deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/entity/Member.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/entity/Member.java
@@ -59,8 +59,5 @@ public class Member extends BaseEntity {
         this.clientId = "";
         this.nickname = "알 수 없음";
         this.deviceToken = null;
-        if (!privateLogs.isEmpty()) {
-            privateLogs.clear();
-        }
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/AuthServiceImpl.java
@@ -2,6 +2,7 @@ package com.macrosoft.modakserver.domain.member.service;
 
 import com.macrosoft.modakserver.config.jwt.JwtProperties;
 import com.macrosoft.modakserver.config.jwt.JwtUtil;
+import com.macrosoft.modakserver.domain.log.repository.PrivateLogRepository;
 import com.macrosoft.modakserver.domain.member.dto.MemberResponse;
 import com.macrosoft.modakserver.domain.member.entity.Member;
 import com.macrosoft.modakserver.domain.member.entity.PermissionRole;
@@ -25,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthServiceImpl implements AuthService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final PrivateLogRepository privateLogRepository;
     private final JwtUtil jwtUtil;
     private final JwtProperties jwtProperties;
 
@@ -121,8 +123,10 @@ public class AuthServiceImpl implements AuthService {
     public void deactivate(String clientId) {
         logout(clientId);
         Member member = findMemberByClientId(clientId);
-
         member.deactivate();
+        int deletedPrivateLogs = privateLogRepository.deleteAllByMemberId(member.getId());
+        log.info("Member deactivated: {} {}, Deleted PrivateLog Count: {}", member.getId(), member.getNickname(),
+                deletedPrivateLogs);
     }
 
     private Member findMemberByClientId(String clientId) {

--- a/src/test/java/com/macrosoft/modakserver/domain/log/service/LogServiceTest.java
+++ b/src/test/java/com/macrosoft/modakserver/domain/log/service/LogServiceTest.java
@@ -1,0 +1,96 @@
+package com.macrosoft.modakserver.domain.log.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.macrosoft.modakserver.domain.log.dto.LogRequest;
+import com.macrosoft.modakserver.domain.log.dto.LogRequest.PrivateLogInfo;
+import com.macrosoft.modakserver.domain.log.dto.LogRequest.PrivateLogInfos;
+import com.macrosoft.modakserver.domain.log.dto.LogResponse;
+import com.macrosoft.modakserver.domain.log.entity.Location;
+import com.macrosoft.modakserver.domain.log.entity.PrivateLog;
+import com.macrosoft.modakserver.domain.log.repository.PrivateLogRepository;
+import com.macrosoft.modakserver.domain.member.entity.Member;
+import com.macrosoft.modakserver.domain.member.entity.PermissionRole;
+import com.macrosoft.modakserver.domain.member.entity.SocialType;
+import com.macrosoft.modakserver.domain.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class LogServiceTest {
+    @Autowired
+    private LogService logService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PrivateLogRepository privateLogRepository;
+    private Member member0;
+
+    @BeforeEach
+    void setUp() {
+        member0 = memberRepository.save(Member.builder()
+                .clientId("clientId0")
+                .socialType(SocialType.APPLE)
+                .nickname("nickname0")
+                .permissionRole(PermissionRole.CLIENT)
+                .build()
+        );
+    }
+
+    @Nested
+    class uploadPrivateLogTests {
+        @Test
+        void 개인_장작_정보_업로드_성공_반환값_검사() {
+            // given
+            String address = "주소";
+            Double minLatitude = 1.0;
+            Double maxLatitude = 2.0;
+            Double minLongitude = 3.0;
+            Double maxLongitude = 4.0;
+            LocalDateTime startAt = LocalDateTime.now();
+            LocalDateTime endAt = LocalDateTime.now().plusMinutes(10);
+
+            LogRequest.PrivateLogInfos privateLogInfos = PrivateLogInfos.builder()
+                    .privateLogInfos(List.of(PrivateLogInfo.builder()
+                            .address(address)
+                            .minLatitude(minLatitude)
+                            .maxLatitude(maxLatitude)
+                            .minLongitude(minLongitude)
+                            .maxLongitude(maxLongitude)
+                            .startAt(startAt)
+                            .endAt(endAt)
+                            .build()))
+                    .build();
+
+            // when
+            LogResponse.LogIds logIds = logService.uploadPrivateLog(member0, privateLogInfos);
+
+            // then
+            Location expectedLocation = Location.builder()
+                    .address(address)
+                    .minLatitude(minLatitude)
+                    .maxLatitude(maxLatitude)
+                    .minLongitude(minLongitude)
+                    .maxLongitude(maxLongitude)
+                    .build();
+
+            assertThat(logIds.getLogIds()).isNotEmpty();
+            PrivateLog privateLog = privateLogRepository.findById(logIds.getLogIds().get(0)).orElseThrow();
+            assertThat(privateLog.getLocation()).usingRecursiveComparison()
+                    .ignoringFields("id", "createdAt", "updatedAt")
+                    .isEqualTo(expectedLocation);
+            assertThat(privateLog.getStartAt()).isEqualTo(startAt);
+            assertThat(privateLog.getEndAt()).isEqualTo(endAt);
+            assertThat(privateLog.getMember()).usingRecursiveComparison()
+                    .ignoringFields("id", "createdAt", "updatedAt")
+                    .isEqualTo(member0);
+        }
+    }
+}

--- a/src/test/java/com/macrosoft/modakserver/domain/log/service/LogServiceTest.java
+++ b/src/test/java/com/macrosoft/modakserver/domain/log/service/LogServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.macrosoft.modakserver.domain.log.dto.LogRequest;
 import com.macrosoft.modakserver.domain.log.dto.LogRequest.PrivateLogInfo;
 import com.macrosoft.modakserver.domain.log.dto.LogRequest.PrivateLogInfos;
-import com.macrosoft.modakserver.domain.log.dto.LogResponse;
 import com.macrosoft.modakserver.domain.log.entity.Location;
 import com.macrosoft.modakserver.domain.log.entity.PrivateLog;
 import com.macrosoft.modakserver.domain.log.repository.PrivateLogRepository;
@@ -55,7 +54,7 @@ class LogServiceTest {
             Double minLongitude = 3.0;
             Double maxLongitude = 4.0;
             LocalDateTime startAt = LocalDateTime.now();
-            LocalDateTime endAt = LocalDateTime.now().plusMinutes(10);
+            LocalDateTime endAt = startAt.plusMinutes(10);
 
             LogRequest.PrivateLogInfos privateLogInfos = PrivateLogInfos.builder()
                     .privateLogInfos(List.of(PrivateLogInfo.builder()
@@ -70,7 +69,7 @@ class LogServiceTest {
                     .build();
 
             // when
-            LogResponse.LogIds logIds = logService.uploadPrivateLog(member0, privateLogInfos);
+            List<Long> logIds = logService.uploadPrivateLog(member0, privateLogInfos).getLogIds();
 
             // then
             Location expectedLocation = Location.builder()
@@ -81,8 +80,8 @@ class LogServiceTest {
                     .maxLongitude(maxLongitude)
                     .build();
 
-            assertThat(logIds.getLogIds()).isNotEmpty();
-            PrivateLog privateLog = privateLogRepository.findById(logIds.getLogIds().get(0)).orElseThrow();
+            assertThat(logIds).isNotEmpty();
+            PrivateLog privateLog = privateLogRepository.findById(logIds.get(0)).orElseThrow();
             assertThat(privateLog.getLocation()).usingRecursiveComparison()
                     .ignoringFields("id", "createdAt", "updatedAt")
                     .isEqualTo(expectedLocation);

--- a/src/test/java/com/macrosoft/modakserver/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/macrosoft/modakserver/domain/member/service/MemberServiceTest.java
@@ -19,16 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 class MemberServiceTest {
     @Autowired
     private MemberService memberService;
-
     @Autowired
     private MemberRepository memberRepository;
-
     private Member member;
 
     @BeforeEach
     void setUp() {
         member = memberRepository.save(Member.builder()
-                .id(1L)
                 .clientId("clientId")
                 .socialType(SocialType.APPLE)
                 .nickname("nickname")


### PR DESCRIPTION
<!-- 제목 예시 -->
<!-- [FEAT/#6] 설명 -->
## 📝 작업 내용

- 회원 탈퇴 시 개인 장작 정보 삭제

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
### 설명

회원 탈퇴시 업로드 했던 개인 장작 정보를 삭제합니다.

### 스크린샷 (선택)

<img width="317" alt="image" src="https://github.com/user-attachments/assets/074b7ff7-7f81-4caf-9792-e096663ca151">


## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성하거나 커멘트로 남겨주세요
 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
