### PR TITLE
[FEAT] s3 이미지 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,6 @@ dependencies {
 
     // AWS S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.520'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,11 @@ dependencies {
 
     // swagger path=/swagger-ui/index.html#
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // AWS S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.520'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/macrosoft/modakserver/config/S3Config.java
+++ b/src/main/java/com/macrosoft/modakserver/config/S3Config.java
@@ -1,0 +1,29 @@
+package com.macrosoft.modakserver.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/macrosoft/modakserver/domain/image/component/S3ImageComponent.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/component/S3ImageComponent.java
@@ -1,0 +1,119 @@
+package com.macrosoft.modakserver.domain.image.component;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.macrosoft.modakserver.domain.image.exception.ImageErrorCode;
+import com.macrosoft.modakserver.global.exception.CustomException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3ImageComponent {
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    public String upload(MultipartFile image, String folderName) {
+        if (image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
+            throw new CustomException(ImageErrorCode.EMPTY_FILE_EXCEPTION);
+        }
+        return this.uploadImage(image, folderName);
+    }
+
+    private String uploadImage(MultipartFile image, String folderName) {
+        this.validateImageFileExtention(Objects.requireNonNull(image.getOriginalFilename()));
+        try {
+            return this.uploadImageToS3(image, folderName);
+        } catch (IOException e) {
+            throw new CustomException(ImageErrorCode.IO_EXCEPTION_ON_IMAGE_UPLOAD);
+        }
+    }
+
+    private void validateImageFileExtention(String filename) {
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            throw new CustomException(ImageErrorCode.NO_FILE_EXTENTION);
+        }
+
+        String extention = filename.substring(lastDotIndex + 1).toLowerCase();
+        List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif", "webp", "heif");
+
+        if (!allowedExtentionList.contains(extention)) {
+            throw new CustomException(ImageErrorCode.INVALID_FILE_EXTENTION);
+        }
+    }
+
+    private String uploadImageToS3(MultipartFile image, String folderName) throws IOException {
+        String originalFilename = image.getOriginalFilename(); //원본 파일 명
+        String extention = Objects.requireNonNull(originalFilename)
+                .substring(originalFilename.lastIndexOf(".")); //확장자 명
+
+//        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename; // 변경된 파일 명
+        String s3FileName = folderName + UUID.randomUUID() + extention; // 매개변수로 받은 이름과 확장자로 파일명 생성
+
+        InputStream is = image.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(is);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/" + extention);
+        metadata.setContentLength(bytes.length);
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+        try {
+            PutObjectRequest putObjectRequest =
+                    new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata);
+            s3Client.putObject(putObjectRequest); // put image to S3
+        } catch (Exception e) {
+            log.error("Failed to upload image to S3.", e);
+            log.error("Bucket: {}, S3 Key: {}, Metadata: ContentType={}, ContentLength={}",
+                    bucketName, s3FileName, metadata.getContentType(), metadata.getContentLength());
+            throw new CustomException(ImageErrorCode.PUT_OBJECT_EXCEPTION);
+        } finally {
+            byteArrayInputStream.close();
+            is.close();
+        }
+
+        return s3Client.getUrl(bucketName, s3FileName).toString();
+    }
+
+    public void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);
+        try {
+            s3Client.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (Exception e) {
+            throw new CustomException(ImageErrorCode.IO_EXCEPTION_ON_IMAGE_DELETE);
+        }
+    }
+
+    private String getKeyFromImageAddress(String imageAddress) {
+        try {
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1); // 맨 앞의 '/' 제거
+        } catch (MalformedURLException e) {
+            throw new CustomException(ImageErrorCode.MALFORMED_URL_EXCEPTION);
+        } catch (UnsupportedEncodingException e) {
+            throw new CustomException(ImageErrorCode.UNSUPPORTED_ENCODING_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/com/macrosoft/modakserver/domain/image/controller/ImageController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/controller/ImageController.java
@@ -1,0 +1,28 @@
+package com.macrosoft.modakserver.domain.image.controller;
+
+import com.macrosoft.modakserver.domain.image.dto.ImageResponse;
+import com.macrosoft.modakserver.domain.image.service.ImageService;
+import com.macrosoft.modakserver.global.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/images")
+@Tag(name = "Image API", description = "S3로 이미지를 업로드 하는 API 입니다.")
+public class ImageController {
+    private final ImageService imageService;
+
+    @Operation(summary = "사진 업로드", description = "S3 버켓에 사진을 업로드하여 해당 사진의 URL 을 반환합니다.")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public BaseResponse<ImageResponse.ImageUrl> uploadAvatarImage(@RequestPart(value = "image") MultipartFile image) {
+        return BaseResponse.onSuccess(imageService.uploadImage(image));
+    }
+}

--- a/src/main/java/com/macrosoft/modakserver/domain/image/dto/ImageResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/dto/ImageResponse.java
@@ -1,0 +1,18 @@
+package com.macrosoft.modakserver.domain.image.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ImageResponse {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ImageUrl {
+        @Schema(description = "이미지 URL", example = "https://example.com/image.png")
+        private String imageUrl;
+    }
+}

--- a/src/main/java/com/macrosoft/modakserver/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/exception/ImageErrorCode.java
@@ -1,0 +1,34 @@
+package com.macrosoft.modakserver.domain.image.exception;
+
+import com.macrosoft.modakserver.global.exception.ErrorCode;
+import com.macrosoft.modakserver.global.exception.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ImageErrorCode implements ErrorCodeInterface {
+    EMPTY_FILE_EXCEPTION("I001", "업로드된 파일이 없거나 파일 이름이 비어 있습니다.", HttpStatus.BAD_REQUEST),
+    IO_EXCEPTION_ON_IMAGE_UPLOAD("I002", "이미지 업로드 중에 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    NO_FILE_EXTENTION("I003", "파일에 확장자가 포함되어 있지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_FILE_EXTENTION("I004", "지원되지 않는 파일 형식입니다. (허용 형식: jpg, jpeg, png, gif, webp, heif)",
+            HttpStatus.BAD_REQUEST),
+    PUT_OBJECT_EXCEPTION("I005", "이미지를 S3에 저장하는 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    IO_EXCEPTION_ON_IMAGE_DELETE("I006", "S3에서 이미지를 삭제하는 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    MALFORMED_URL_EXCEPTION("I007", "이미지 주소 형식이 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+    UNSUPPORTED_ENCODING_EXCEPTION("I008", "이미지 주소의 인코딩 방식이 지원되지 않습니다.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.builder()
+                .code(code)
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/macrosoft/modakserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/service/ImageService.java
@@ -1,0 +1,10 @@
+package com.macrosoft.modakserver.domain.image.service;
+
+import com.macrosoft.modakserver.domain.image.dto.ImageResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageService {
+    ImageResponse.ImageUrl uploadImage(MultipartFile image);
+
+    void deleteImageFromS3(String imageUrl);
+}

--- a/src/main/java/com/macrosoft/modakserver/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/service/ImageServiceImpl.java
@@ -1,0 +1,26 @@
+package com.macrosoft.modakserver.domain.image.service;
+
+import com.macrosoft.modakserver.domain.image.component.S3ImageComponent;
+import com.macrosoft.modakserver.domain.image.dto.ImageResponse.ImageUrl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+    private final S3ImageComponent s3ImageComponent;
+
+    @Override
+    public ImageUrl uploadImage(MultipartFile image) {
+        String folderName = "dev/"; // TODO: 추후 프로필 이미지, 게시글 이미지 등 다양한 이미지 업로드를 위한 폴더명 설정
+        return ImageUrl.builder()
+                .imageUrl(s3ImageComponent.upload(image, folderName))
+                .build();
+    }
+
+    @Override
+    public void deleteImageFromS3(String imageUrl) {
+        s3ImageComponent.deleteImageFromS3(imageUrl);
+    }
+}


### PR DESCRIPTION
<!-- 제목 예시 -->
<!-- [FEAT/#6] 설명 -->
## 📝 작업 내용

- 이미지 업로드 API 구현

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
### 설명

이미지 업로드 API 구현했습니다.

다만, 임시 API로 추후 서버에서 Presigned URL 을 제공하면
클라이언트에서 S3로 바로 업로드 하도록 구현해야 합니다.

또한 모닥불 별로 이미지 정책도 생각해봐야 합니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성하거나 커멘트로 남겨주세요
 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
