### PR TITLE
[FEAT] 회원들 닉네임 가져오기

### DIFF
--- a/src/main/java/com/macrosoft/modakserver/domain/log/controller/LogController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/controller/LogController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class LogController {
     private final LogService logService;
 
-    @Operation(summary = "개인 장작 정보 업로드", description = "개인 장작 정보들을 업로드합니다.")
+    @Operation(summary = "개인 장작 정보 업로드", description = "개인 장작 정보들을 업로드합니다.", deprecated = true)
     @PostMapping("/private")
     public BaseResponse<LogIds> uploadPrivateLog(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/macrosoft/modakserver/domain/log/dto/LogRequest.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/dto/LogRequest.java
@@ -2,31 +2,19 @@ package com.macrosoft.modakserver.domain.log.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public class LogRequest {
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class PrivateLogInfo {
-        private String address;
-        private Double minLatitude;
-        private Double maxLatitude;
-        private Double minLongitude;
-        private Double maxLongitude;
-        private LocalDateTime startAt;
-        private LocalDateTime endAt;
+    public record PrivateLogInfo(
+            String address,
+            Double minLatitude,
+            Double maxLatitude,
+            Double minLongitude,
+            Double maxLongitude,
+            LocalDateTime startAt,
+            LocalDateTime endAt
+    ) {
     }
 
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class PrivateLogInfos {
-        private List<PrivateLogInfo> privateLogInfos;
+    public record PrivateLogInfos(List<PrivateLogInfo> privateLogInfos) {
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/log/dto/LogResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/dto/LogResponse.java
@@ -1,17 +1,8 @@
 package com.macrosoft.modakserver.domain.log.dto;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public class LogResponse {
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class LogIds {
-        private List<Long> logIds;
+    public record LogIds(List<Long> logIds) {
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/log/service/LogServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/service/LogServiceImpl.java
@@ -23,18 +23,18 @@ public class LogServiceImpl implements LogService {
     public LogIds uploadPrivateLog(Member member, PrivateLogInfos privateLogInfoList) {
         List<Long> longList = new ArrayList<>();
 
-        for (PrivateLogInfo logInfo : privateLogInfoList.getPrivateLogInfos()) {
+        for (PrivateLogInfo logInfo : privateLogInfoList.privateLogInfos()) {
             // PrivateLog 엔티티 생성
             PrivateLog privateLog = PrivateLog.builder()
                     .member(member)
-                    .startAt(logInfo.getStartAt())
-                    .endAt(logInfo.getEndAt())
+                    .startAt(logInfo.startAt())
+                    .endAt(logInfo.endAt())
                     .location(Location.builder()
-                            .minLatitude(logInfo.getMinLatitude())
-                            .maxLatitude(logInfo.getMaxLatitude())
-                            .minLongitude(logInfo.getMinLongitude())
-                            .maxLongitude(logInfo.getMaxLongitude())
-                            .address(logInfo.getAddress())
+                            .minLatitude(logInfo.minLatitude())
+                            .maxLatitude(logInfo.maxLatitude())
+                            .minLongitude(logInfo.minLongitude())
+                            .maxLongitude(logInfo.maxLongitude())
+                            .address(logInfo.address())
                             .build()
                     )
                     .build();
@@ -43,8 +43,6 @@ public class LogServiceImpl implements LogService {
             longList.add(savedLog.getId());
         }
 
-        return LogIds.builder()
-                .logIds(longList)
-                .build();
+        return new LogIds(longList);
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/controller/AuthController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/controller/AuthController.java
@@ -38,9 +38,9 @@ public class AuthController {
         return BaseResponse.onSuccess(
                 authService.login(
                         socialType,
-                        request.getAuthorizationCode(),
-                        request.getIdentityToken(),
-                        request.getEncryptedUserIdentifier()
+                        request.authorizationCode(),
+                        request.identityToken(),
+                        request.encryptedUserIdentifier()
                 )
         );
     }
@@ -74,6 +74,6 @@ public class AuthController {
     public BaseResponse<MemberResponse.AccessToken> refreshAccessToken(
             @RequestBody MemberRequest.RefreshTokenRequest request
     ) {
-        return BaseResponse.onSuccess(authService.refreshAccessToken(request.getRefreshToken()));
+        return BaseResponse.onSuccess(authService.refreshAccessToken(request.refreshToken()));
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/controller/MemberController.java
@@ -23,22 +23,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
 
-    @Operation(summary = "내 닉네임 가져오기", description = "회원 본인의 닉네임을 가져옵니다.")
-    @GetMapping("/nickname/my")
-    public BaseResponse<MemberResponse.MemberNickname> getMyNickname(
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        Member member = userDetails.getMember();
-        return BaseResponse.onSuccess(memberService.getMyNickname(member));
-    }
-
-    @Operation(summary = "다른 회원들의 닉네임 가져오기", description = "다른 회원들의 닉네임을 가져옵니다.")
-    @GetMapping("/nickname")
-    public BaseResponse<List<MemberResponse.MemberNickname>> getMembersNickname(
-            @RequestParam("memberIds") List<Long> memberIds) {
-        return BaseResponse.onSuccess(memberService.getNicknames(memberIds));
-    }
-
     @Operation(summary = "내 닉네임 변경", description = "회원 본인의 닉네임을 변경합니다.")
     @PatchMapping("/nickname")
     public BaseResponse<MemberResponse.MemberNickname> updateNickname(
@@ -47,5 +31,16 @@ public class MemberController {
     ) {
         Member member = userDetails.getMember();
         return BaseResponse.onSuccess(memberService.updateNickname(member, nickname));
+    }
+
+    @Operation(summary = "회원들의 닉네임 가져오기", description = "회원들의 닉네임을 가져옵니다. 쿼리 파라미터를 비워둘 경우 본인의 닉네임을 가져옵니다.")
+    @GetMapping("/nickname")
+    public BaseResponse<List<MemberResponse.MemberNickname>> getMembersNickname(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(value = "memberIds", required = false) List<Long> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            memberIds = List.of(userDetails.getMember().getId());
+        }
+        return BaseResponse.onSuccess(memberService.getNicknames(memberIds));
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.macrosoft.modakserver.domain.member.service.MemberService;
 import com.macrosoft.modakserver.global.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,20 +23,27 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
 
-    @Operation(summary = "회원 닉네임 가져오기", description = "회원의 닉네임을 가져옵니다.")
-    @GetMapping("/nickname")
-    public BaseResponse<MemberResponse.MemberNickname> getMemberNickname(
+    @Operation(summary = "내 닉네임 가져오기", description = "회원 본인의 닉네임을 가져옵니다.")
+    @GetMapping("/nickname/my")
+    public BaseResponse<MemberResponse.MemberNickname> getMyNickname(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Member member = userDetails.getMember();
-        return BaseResponse.onSuccess(memberService.getMemberNickname(member));
+        return BaseResponse.onSuccess(memberService.getMyNickname(member));
     }
 
-    @Operation(summary = "회원 닉네임 변경", description = "회원의 닉네임을 변경합니다.")
+    @Operation(summary = "다른 회원들의 닉네임 가져오기", description = "다른 회원들의 닉네임을 가져옵니다.")
+    @GetMapping("/nickname")
+    public BaseResponse<List<MemberResponse.MemberNickname>> getMembersNickname(
+            @RequestParam("memberIds") List<Long> memberIds) {
+        return BaseResponse.onSuccess(memberService.getNicknames(memberIds));
+    }
+
+    @Operation(summary = "내 닉네임 변경", description = "회원 본인의 닉네임을 변경합니다.")
     @PatchMapping("/nickname")
     public BaseResponse<MemberResponse.MemberNickname> updateNickname(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam String nickname
+            @RequestParam("nickname") String nickname
     ) {
         Member member = userDetails.getMember();
         return BaseResponse.onSuccess(memberService.updateNickname(member, nickname));

--- a/src/main/java/com/macrosoft/modakserver/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/dto/MemberRequest.java
@@ -1,49 +1,24 @@
 package com.macrosoft.modakserver.domain.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public class MemberRequest {
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class MemberSignIn {
-        @Schema(
-                description = "애플로부터 받은 Authorization Code",
-                defaultValue = "c19074541137c4508ad5ab04301028c28.0.rrwuz.9laqvPNEVlUKyJ7AY-QeLw"
-        )
-        private String authorizationCode;
 
-        @Schema(
-                description = "애플로부터 받은 ID Token.",
-                defaultValue = "eyJraWQiOiJmaDZCczhDIiwiYWaxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcExlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLm9zZ"
-        )
-        private String identityToken;
+    public record MemberSignIn(
+            @Schema(description = "애플로부터 받은 Authorization Code", defaultValue = "c19074541137c4508ad5ab04301028c28.0.rrwuz.9laqvPNEVlUKyJ7AY-QeLw")
+            String authorizationCode,
 
-        @Schema(
-                description = "암호화 된 UserIdentifier",
-                defaultValue = "614c0236d8480a64d9f2214e2486317de1ede78dc59250c806650bce3cbf6ed9"
-        )
-        private String encryptedUserIdentifier;
+            @Schema(description = "애플로부터 받은 ID Token.", defaultValue = "eyJraWQiOiJmaDZCczhDIiwiYWaxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcExlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLm9zZ")
+            String identityToken,
+
+            @Schema(description = "암호화 된 UserIdentifier", defaultValue = "614c0236d8480a64d9f2214e2486317de1ede78dc59250c806650bce3cbf6ed9")
+            String encryptedUserIdentifier
+    ) {
     }
 
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class MemberNickname {
-        @Schema(description = "변경할 닉네임", defaultValue = "새로운 닉네임")
-        private String nickname;
-    }
-
-    @Data
-    public static class RefreshTokenRequest {
-        @Schema(description = "Refresh Token", defaultValue = "refreshToken")
-        private String refreshToken;
+    public record RefreshTokenRequest(
+            @Schema(description = "Refresh Token", defaultValue = "refreshToken")
+            String refreshToken
+    ) {
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/dto/MemberResponse.java
@@ -1,43 +1,12 @@
 package com.macrosoft.modakserver.domain.member.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 public class MemberResponse {
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class MemberLogin {
-        private Long memberId;
-        private String accessToken;
-        private String refreshToken;
+    public record MemberLogin(Long memberId, String accessToken, String refreshToken) {
     }
 
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class MemberNickname {
-        private Long memberId;
-        private String nickname;
+    public record MemberNickname(Long memberId, String nickname) {
     }
 
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class MemberId {
-        private String memberId;
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class AccessToken {
-        private String accessToken;
+    public record AccessToken(String accessToken) {
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/entity/Member.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/entity/Member.java
@@ -1,20 +1,14 @@
 package com.macrosoft.modakserver.domain.member.entity;
 
-import com.macrosoft.modakserver.domain.log.entity.PrivateLog;
 import com.macrosoft.modakserver.global.BaseEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -51,9 +45,10 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PermissionRole permissionRole;
 
-    @Builder.Default
-    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<PrivateLog> privateLogs = new ArrayList<>();
+    // MARK: 개인 장작 업로드 기능 삭제됨
+//    @Builder.Default
+//    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+//    private List<PrivateLog> privateLogs = new ArrayList<>();
 
     public void deactivate() {
         this.clientId = "";

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/AuthServiceImpl.java
@@ -86,9 +86,10 @@ public class AuthServiceImpl implements AuthService {
         logout(clientId);
         Member member = findMemberByClientId(clientId);
         member.deactivate();
-        int deletedPrivateLogs = privateLogRepository.deleteAllByMemberId(member.getId());
-        log.info("Member deactivated: {} {}, Deleted PrivateLog Count: {}", member.getId(), member.getNickname(),
-                deletedPrivateLogs);
+        // MARK: 개인 장작 업로드 기능 삭제됨
+//        int deletedPrivateLogs = privateLogRepository.deleteAllByMemberId(member.getId());
+//        log.info("Member deactivated: {} {}, Deleted PrivateLog Count: {}", member.getId(), member.getNickname(),
+//                deletedPrivateLogs);
     }
 
     private Member createNewMember(String clientId, SocialType socialType) {

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/AuthServiceImpl.java
@@ -43,11 +43,52 @@ public class AuthServiceImpl implements AuthService {
 
         updateOrCreateRefreshToken(encryptedUserIdentifier, refreshToken);
 
-        return MemberResponse.MemberLogin.builder()
-                .memberId(member.getId())
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
+        return new MemberResponse.MemberLogin(member.getId(), accessToken, refreshToken);
+    }
+
+    @Override
+    @Transactional
+    public MemberResponse.AccessToken refreshAccessToken(String refreshToken) {
+        // Refresh Token 검증
+        jwtUtil.validateRefreshToken(refreshToken);
+
+        // Refresh Token 에서 memberId 추출 하고 clientId 가져오기
+        Long memberId = jwtUtil.getMemberId(refreshToken);
+        String clientId = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND))
+                .getClientId();
+
+        RefreshToken storedRefreshToken = refreshTokenRepository.findByClientId(clientId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.MEMBER_NOT_HAVE_TOKEN));
+
+        if (!storedRefreshToken.getToken().equals(refreshToken)) {
+            throw new CustomException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        // 새로운 Access Token 발급
+        Member member = findMemberByClientId(clientId);
+        String newAccessToken = jwtUtil.createAccessToken(member);
+
+        return new MemberResponse.AccessToken(newAccessToken);
+    }
+
+    @Override
+    @Transactional
+    public void logout(String clientId) {
+        if (refreshTokenRepository.deleteByClientId(clientId) == 0) {
+            throw new CustomException(AuthErrorCode.MEMBER_NOT_HAVE_TOKEN);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deactivate(String clientId) {
+        logout(clientId);
+        Member member = findMemberByClientId(clientId);
+        member.deactivate();
+        int deletedPrivateLogs = privateLogRepository.deleteAllByMemberId(member.getId());
+        log.info("Member deactivated: {} {}, Deleted PrivateLog Count: {}", member.getId(), member.getNickname(),
+                deletedPrivateLogs);
     }
 
     private Member createNewMember(String clientId, SocialType socialType) {
@@ -83,53 +124,6 @@ public class AuthServiceImpl implements AuthService {
                 .expirationDate(expirationDate)
                 .build();
         refreshTokenRepository.save(newRefreshToken);
-    }
-
-    @Override
-    @Transactional
-    public MemberResponse.AccessToken refreshAccessToken(String refreshToken) {
-        // Refresh Token 검증
-        jwtUtil.validateRefreshToken(refreshToken);
-
-        // Refresh Token 에서 memberId 추출 하고 clientId 가져오기
-        Long memberId = jwtUtil.getMemberId(refreshToken);
-        String clientId = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND))
-                .getClientId();
-
-        RefreshToken storedRefreshToken = refreshTokenRepository.findByClientId(clientId)
-                .orElseThrow(() -> new CustomException(AuthErrorCode.MEMBER_NOT_HAVE_TOKEN));
-
-        if (!storedRefreshToken.getToken().equals(refreshToken)) {
-            throw new CustomException(AuthErrorCode.INVALID_TOKEN);
-        }
-
-        // 새로운 Access Token 발급
-        Member member = findMemberByClientId(clientId);
-        String newAccessToken = jwtUtil.createAccessToken(member);
-
-        return MemberResponse.AccessToken.builder()
-                .accessToken(newAccessToken)
-                .build();
-    }
-
-    @Override
-    @Transactional
-    public void logout(String clientId) {
-        if (refreshTokenRepository.deleteByClientId(clientId) == 0) {
-            throw new CustomException(AuthErrorCode.MEMBER_NOT_HAVE_TOKEN);
-        }
-    }
-
-    @Override
-    @Transactional
-    public void deactivate(String clientId) {
-        logout(clientId);
-        Member member = findMemberByClientId(clientId);
-        member.deactivate();
-        int deletedPrivateLogs = privateLogRepository.deleteAllByMemberId(member.getId());
-        log.info("Member deactivated: {} {}, Deleted PrivateLog Count: {}", member.getId(), member.getNickname(),
-                deletedPrivateLogs);
     }
 
     private Member findMemberByClientId(String clientId) {

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberService.java
@@ -5,8 +5,6 @@ import com.macrosoft.modakserver.domain.member.entity.Member;
 import java.util.List;
 
 public interface MemberService {
-    MemberResponse.MemberNickname getMyNickname(Member member);
-
     List<MemberResponse.MemberNickname> getNicknames(List<Long> memberIds);
 
     MemberResponse.MemberNickname updateNickname(Member member, String nickname);

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberService.java
@@ -1,9 +1,13 @@
 package com.macrosoft.modakserver.domain.member.service;
 
-import com.macrosoft.modakserver.domain.member.dto.MemberResponse.MemberNickname;
+import com.macrosoft.modakserver.domain.member.dto.MemberResponse;
 import com.macrosoft.modakserver.domain.member.entity.Member;
+import java.util.List;
 
 public interface MemberService {
-    MemberNickname getMemberNickname(Member member);
-    MemberNickname updateNickname(Member member, String nickname);
+    MemberResponse.MemberNickname getMyNickname(Member member);
+
+    List<MemberResponse.MemberNickname> getNicknames(List<Long> memberIds);
+
+    MemberResponse.MemberNickname updateNickname(Member member, String nickname);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberServiceImpl.java
@@ -1,8 +1,10 @@
 package com.macrosoft.modakserver.domain.member.service;
 
+import com.macrosoft.modakserver.domain.member.dto.MemberResponse;
 import com.macrosoft.modakserver.domain.member.dto.MemberResponse.MemberNickname;
 import com.macrosoft.modakserver.domain.member.entity.Member;
 import com.macrosoft.modakserver.domain.member.repository.MemberRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,11 +15,15 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
 
     @Override
-    public MemberNickname getMemberNickname(Member member) {
-        return MemberNickname.builder()
-                .memberId(member.getId())
-                .nickname(member.getNickname())
-                .build();
+    public MemberNickname getMyNickname(Member member) {
+        return new MemberResponse.MemberNickname(member.getId(), member.getNickname());
+    }
+
+    @Override
+    public List<MemberNickname> getNicknames(List<Long> memberIds) {
+        return memberRepository.findAllById(memberIds).stream()
+                .map(member -> new MemberResponse.MemberNickname(member.getId(), member.getNickname()))
+                .toList();
     }
 
     @Override
@@ -25,9 +31,6 @@ public class MemberServiceImpl implements MemberService {
     public MemberNickname updateNickname(Member member, String nickname) {
         member.setNickname(nickname);
         memberRepository.save(member);
-        return MemberNickname.builder()
-                .memberId(member.getId())
-                .nickname(member.getNickname())
-                .build();
+        return new MemberNickname(member.getId(), member.getNickname());
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberServiceImpl.java
@@ -3,7 +3,9 @@ package com.macrosoft.modakserver.domain.member.service;
 import com.macrosoft.modakserver.domain.member.dto.MemberResponse;
 import com.macrosoft.modakserver.domain.member.dto.MemberResponse.MemberNickname;
 import com.macrosoft.modakserver.domain.member.entity.Member;
+import com.macrosoft.modakserver.domain.member.exception.MemberErrorCode;
 import com.macrosoft.modakserver.domain.member.repository.MemberRepository;
+import com.macrosoft.modakserver.global.exception.CustomException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,9 +23,17 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public List<MemberNickname> getNicknames(List<Long> memberIds) {
-        return memberRepository.findAllById(memberIds).stream()
+        List<Member> members = memberRepository.findAllById(memberIds);
+        validateMemberNotFound(members, memberIds);
+        return members.stream()
                 .map(member -> new MemberResponse.MemberNickname(member.getId(), member.getNickname()))
                 .toList();
+    }
+
+    private void validateMemberNotFound(List<Member> members, List<Long> memberIds) {
+        if (members.size() != memberIds.size()) {
+            throw new CustomException(MemberErrorCode.MEMBER_NOT_FOUND);
+        }
     }
 
     @Override

--- a/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/member/service/MemberServiceImpl.java
@@ -17,11 +17,6 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
 
     @Override
-    public MemberNickname getMyNickname(Member member) {
-        return new MemberResponse.MemberNickname(member.getId(), member.getNickname());
-    }
-
-    @Override
     public List<MemberNickname> getNicknames(List<Long> memberIds) {
         List<Member> members = memberRepository.findAllById(memberIds);
         validateMemberNotFound(members, memberIds);

--- a/src/main/java/com/macrosoft/modakserver/test/controller/TestController.java
+++ b/src/main/java/com/macrosoft/modakserver/test/controller/TestController.java
@@ -3,6 +3,7 @@ package com.macrosoft.modakserver.test.controller;
 import com.macrosoft.modakserver.domain.member.entity.Member;
 import com.macrosoft.modakserver.global.BaseResponse;
 import com.macrosoft.modakserver.test.service.TestService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Test API")
 public class TestController {
     private final TestService testService;
-    
+
+    @Operation(deprecated = true)
     @GetMapping("/get")
     public BaseResponse<List<Member>> get() {
         List<Member> memberList = testService.get();

--- a/src/test/java/com/macrosoft/modakserver/domain/log/service/LogServiceTest.java
+++ b/src/test/java/com/macrosoft/modakserver/domain/log/service/LogServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.macrosoft.modakserver.domain.log.dto.LogRequest;
 import com.macrosoft.modakserver.domain.log.dto.LogRequest.PrivateLogInfo;
-import com.macrosoft.modakserver.domain.log.dto.LogRequest.PrivateLogInfos;
 import com.macrosoft.modakserver.domain.log.entity.Location;
 import com.macrosoft.modakserver.domain.log.entity.PrivateLog;
 import com.macrosoft.modakserver.domain.log.repository.PrivateLogRepository;
@@ -56,20 +55,13 @@ class LogServiceTest {
             LocalDateTime startAt = LocalDateTime.now();
             LocalDateTime endAt = startAt.plusMinutes(10);
 
-            LogRequest.PrivateLogInfos privateLogInfos = PrivateLogInfos.builder()
-                    .privateLogInfos(List.of(PrivateLogInfo.builder()
-                            .address(address)
-                            .minLatitude(minLatitude)
-                            .maxLatitude(maxLatitude)
-                            .minLongitude(minLongitude)
-                            .maxLongitude(maxLongitude)
-                            .startAt(startAt)
-                            .endAt(endAt)
-                            .build()))
-                    .build();
+            LogRequest.PrivateLogInfos privateLogInfos = new LogRequest.PrivateLogInfos(
+                    List.of(new PrivateLogInfo(address, minLatitude, maxLatitude, minLongitude, maxLongitude, startAt,
+                            endAt))
+            );
 
             // when
-            List<Long> logIds = logService.uploadPrivateLog(member0, privateLogInfos).getLogIds();
+            List<Long> logIds = logService.uploadPrivateLog(member0, privateLogInfos).logIds();
 
             // then
             Location expectedLocation = Location.builder()

--- a/src/test/java/com/macrosoft/modakserver/domain/member/service/AuthServiceTest.java
+++ b/src/test/java/com/macrosoft/modakserver/domain/member/service/AuthServiceTest.java
@@ -203,6 +203,7 @@ class AuthServiceTest {
         }
 
         @Test
+        @Disabled
         void 회원탈퇴_성공_프라이빗로그_삭제() {
             // given
             Optional<Member> optionalMember = memberRepository.findById(memberLogin.memberId());
@@ -223,7 +224,7 @@ class AuthServiceTest {
             authService.deactivate(encryptedUserIdentifier);
 
             // then
-            assertThat(member.getPrivateLogs()).isEmpty();
+//            assertThat(member.getPrivateLogs()).isEmpty();
             Optional<PrivateLog> optionalPrivateLog1 = privateLogRepository.findById(logIds.get(0));
             assertThat(optionalPrivateLog1).isNotPresent();
         }

--- a/src/test/java/com/macrosoft/modakserver/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/macrosoft/modakserver/domain/member/service/MemberServiceTest.java
@@ -39,11 +39,11 @@ class MemberServiceTest {
         @Test
         void 이름_가져오기_성공_반환값_검사() {
             // when
-            MemberResponse.MemberNickname memberNickname = memberService.getMemberNickname(member);
+            MemberResponse.MemberNickname memberNickname = memberService.getMyNickname(member);
 
             // then
-            assertThat(memberNickname.getMemberId()).isEqualTo(member.getId());
-            assertThat(memberNickname.getNickname()).isEqualTo(member.getNickname());
+            assertThat(memberNickname.memberId()).isEqualTo(member.getId());
+            assertThat(memberNickname.nickname()).isEqualTo(member.getNickname());
         }
     }
 
@@ -58,8 +58,8 @@ class MemberServiceTest {
             MemberResponse.MemberNickname memberNickname = memberService.updateNickname(member, nickname);
 
             // then
-            assertThat(memberNickname.getMemberId()).isEqualTo(member.getId());
-            assertThat(memberNickname.getNickname()).isEqualTo(nickname);
+            assertThat(memberNickname.memberId()).isEqualTo(member.getId());
+            assertThat(memberNickname.nickname()).isEqualTo(nickname);
         }
     }
 }


### PR DESCRIPTION
<!-- 제목 예시 -->
<!-- [FEAT/#6] 설명 -->
## 📝 작업 내용

- 회원들 닉네임 가져오기
- 필요 없는 API 들 Swagger 상에서 deprecated 처리
  - test / get
  - privateLogUpload
- 개인 장작 관련 로직 삭제 (주석처리)
- 모든 dto class 에서 record 로 변경
- 내 닉네임 가져오기, 다른 회원 닉네임 가져오기 API 통합

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
### 설명

### 스크린샷 (선택)
<img width="315" alt="image" src="https://github.com/user-attachments/assets/007863c3-df77-4437-9f71-a9bd20032fb6">

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성하거나 커멘트로 남겨주세요
 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
