### PR TITLE
[FEAT] 장작 이미지 기능 추가

### DIFF
--- a/src/main/java/com/macrosoft/modakserver/config/jwt/JwtUtil.java
+++ b/src/main/java/com/macrosoft/modakserver/config/jwt/JwtUtil.java
@@ -18,12 +18,14 @@ import java.util.Date;
 import java.util.Optional;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtUtil {
@@ -101,6 +103,9 @@ public class JwtUtil {
         } catch (SecurityException | MalformedJwtException e) {
             throw new CustomException(AuthErrorCode.INVALID_TOKEN);
         } catch (ExpiredJwtException e) {
+            Claims payload = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+            log.error("만료된 토큰입니다.\n 토큰타입: {}, 멤버아이디: {}, 주제 (멤버아이디): {}, 발행날짜: {}, 만료날짜: {}", payload.get("tokenType"),
+                    payload.get("memberId"), payload.getSubject(), payload.getIssuedAt(), payload.getExpiration());
             throw new CustomException(AuthErrorCode.EXPIRED_TOKEN);
         } catch (UnsupportedJwtException e) {
             throw new CustomException(AuthErrorCode.UNSUPPORTED_TOKEN);

--- a/src/main/java/com/macrosoft/modakserver/domain/campfire/dto/CampfireResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/campfire/dto/CampfireResponse.java
@@ -2,9 +2,7 @@ package com.macrosoft.modakserver.domain.campfire.dto;
 
 import com.macrosoft.modakserver.domain.image.dto.ImageResponse.ImageDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public class CampfireResponse {

--- a/src/main/java/com/macrosoft/modakserver/domain/campfire/service/CampfireService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/campfire/service/CampfireService.java
@@ -15,7 +15,7 @@ public interface CampfireService {
     CampfireResponse.CampfireName getCampfireName(Member member, int campfirePin);
 
     CampfireResponse.CampfirePin joinCampfire(Member member, int campfirePin, String campfireName);
-    
+
     CampfireResponse.CampfireName updateCampfireName(Member member, int campfirePin, String newCampfireName);
 
     CampfireResponse.CampfirePin leaveCampfire(Member member, int campfirePin);
@@ -26,5 +26,5 @@ public interface CampfireService {
 
     void validateMemberInCampfire(Member member, Campfire campfire);
 
-    ImageDTO getTodayImage(Campfire campfire);
+    ImageDTO getTodayImageDTO(Campfire campfire);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/campfire/service/CampfireServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/campfire/service/CampfireServiceImpl.java
@@ -99,20 +99,20 @@ public class CampfireServiceImpl implements CampfireService {
                             .map(MemberCampfire::getMember)
                             .map(Member::getNickname)
                             .collect(toSet()),
-                    getTodayImage(campfire).name()
+                    getTodayImageDTO(campfire).name()
             ));
         }
         return new CampfireResponse.CampfireInfos(campfireInfos);
     }
 
-    public ImageDTO getTodayImage(Campfire campfire) {
+    public ImageDTO getTodayImageDTO(Campfire campfire) {
         LogImage todayImage = campfire.getTodayImage();
         ImageDTO todayImageDTO;
         if (todayImage == null) {
-            todayImageDTO = new ImageDTO("", new ArrayList<>());
+            todayImageDTO = new ImageDTO(0L, "", new ArrayList<>());
         } else {
             // TODO: 감정 표현
-            todayImageDTO = new ImageDTO(todayImage.getName(), new ArrayList<>());
+            todayImageDTO = new ImageDTO(todayImage.getId(), todayImage.getName(), new ArrayList<>());
         }
         return todayImageDTO;
     }
@@ -126,7 +126,7 @@ public class CampfireServiceImpl implements CampfireService {
         return new CampfireResponse.CampfireMain(
                 campfire.getPin(),
                 campfire.getName(),
-                getTodayImage(campfire),
+                getTodayImageDTO(campfire),
                 campfire.getMemberCampfires().stream()
                         .map(MemberCampfire::getMember)
                         .map(Member::getId)
@@ -160,7 +160,7 @@ public class CampfireServiceImpl implements CampfireService {
         addMemberToCampfire(memberInDB, campfire);
         return new CampfirePin(campfire.getPin());
     }
-    
+
 
     private boolean isCampfireMemberFull(Campfire campfire) {
         return campfire.getMemberCampfires().size() >= 6;

--- a/src/main/java/com/macrosoft/modakserver/domain/campfire/service/TodayImageService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/campfire/service/TodayImageService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -16,7 +17,8 @@ import org.springframework.stereotype.Service;
 public class TodayImageService {
     private final CampfireRepository campfireRepository;
 
-    @Scheduled(cron = "0 0 4 * * ?") // 하루 한번씩 서비스 전체 모닥불의 오늘의 사진 업데이트
+    @Transactional
+    @Scheduled(cron = "0 0 4 * * ?", zone = "Asia/Seoul") // 하루 한번씩 서비스 전체 모닥불의 오늘의 사진 업데이트
     public void registerTodayImage() {
         log.info("오늘의 사진 등록 서비스 시작");
         int successCount = 0;

--- a/src/main/java/com/macrosoft/modakserver/domain/image/controller/ImageController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/controller/ImageController.java
@@ -33,7 +33,7 @@ public class ImageController {
 
     @Operation(summary = "사진 상세보기", description = "모닥불에 업로드된 사진의 세부 정보를 봅니다. 사진의 메타데이터와 감정표현을 불러옵니다. 사진을 눌러서 크게 본 화면에서 사용됩니다.")
     @GetMapping("/campfires/{campfirePin}/images/{imageId}")
-    public BaseResponse<ImageResponse.ImageDTO> getImageDetail(
+    public BaseResponse<ImageResponse.ImageDetail> getImageDetail(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "모닥불 핀 번호", example = "111111")
             @PathVariable("campfirePin") int campfirePin,

--- a/src/main/java/com/macrosoft/modakserver/domain/image/controller/ImageController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/controller/ImageController.java
@@ -1,12 +1,17 @@
 package com.macrosoft.modakserver.domain.image.controller;
 
+import com.macrosoft.modakserver.config.security.CustomUserDetails;
 import com.macrosoft.modakserver.domain.image.dto.ImageResponse;
 import com.macrosoft.modakserver.domain.image.service.ImageService;
 import com.macrosoft.modakserver.global.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -15,14 +20,26 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/images")
+@RequestMapping("/api")
 @Tag(name = "Image API", description = "S3로 이미지를 업로드 하는 API 입니다.")
 public class ImageController {
     private final ImageService imageService;
 
     @Operation(summary = "사진 업로드", description = "S3 버켓에 사진을 업로드하여 해당 사진의 URL 을 반환합니다.")
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public BaseResponse<ImageResponse.ImageUrl> uploadAvatarImage(@RequestPart(value = "image") MultipartFile image) {
         return BaseResponse.onSuccess(imageService.uploadImage(image));
+    }
+
+    @Operation(summary = "사진 상세보기", description = "모닥불에 업로드된 사진의 세부 정보를 봅니다. 사진의 메타데이터와 감정표현을 불러옵니다. 사진을 눌러서 크게 본 화면에서 사용됩니다.")
+    @GetMapping("/campfires/{campfirePin}/images/{imageId}")
+    public BaseResponse<ImageResponse.ImageDTO> getImageDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "모닥불 핀 번호", example = "111111")
+            @PathVariable("campfirePin") int campfirePin,
+            @Parameter(description = "사진 아이디", example = "1")
+            @PathVariable("imageId") Long imageId
+    ) {
+        return BaseResponse.onSuccess(imageService.getImageDetail(userDetails.getMember(), campfirePin, imageId));
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/image/dto/ImageResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/dto/ImageResponse.java
@@ -10,12 +10,16 @@ public class ImageResponse {
     }
 
     public record ImageDTO(
+            @Schema(description = "이미지 ID", example = "1")
+            Long imageId,
             @Schema(description = "이미지 이름", example = "/dev/772b94e6-2081-4d1d-b331-20015cc287e0.jpeg")
             String name,
             List<ImageEmotionDTO> emotions) {
     }
 
     public record ImageName(
+            @Schema(description = "이미지 ID", example = "1")
+            Long imageId,
             @Schema(description = "이미지 이름", example = "/dev/772b94e6-2081-4d1d-b331-20015cc287e0.jpeg")
             String imageName) {
     }
@@ -25,10 +29,5 @@ public class ImageResponse {
             String memberNickname,
             @Schema(description = "감정표현", example = "😀")
             String emotion) {
-    }
-
-    public record ImageId(
-            @Schema(description = "이미지 ID", example = "1")
-            Long imageId) {
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/image/dto/ImageResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/dto/ImageResponse.java
@@ -1,6 +1,8 @@
 package com.macrosoft.modakserver.domain.image.dto;
 
+import com.macrosoft.modakserver.domain.image.entity.LogImage;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class ImageResponse {
@@ -15,6 +17,36 @@ public class ImageResponse {
             @Schema(description = "이미지 이름", example = "/dev/772b94e6-2081-4d1d-b331-20015cc287e0.jpeg")
             String name,
             List<ImageEmotionDTO> emotions) {
+    }
+
+    public record ImageDetail(
+            @Schema(description = "이미지 ID", example = "1")
+            Long imageId,
+            @Schema(description = "이미지 이름", example = "/dev/772b94e6-2081-4d1d-b331-20015cc287e0.jpeg")
+            String imageName,
+            double latitude,
+            double longitude,
+            LocalDateTime takenAt,
+            String memberNickname,
+            Long logId,
+            List<ImageEmotionDTO> emotions) {
+        public static ImageDetail of(LogImage logImage) {
+            return new ImageDetail(
+                    logImage.getId(),
+                    logImage.getName(),
+                    logImage.getLatitude(),
+                    logImage.getLongitude(),
+                    logImage.getTakenAt(),
+                    logImage.getMember().getNickname(),
+                    logImage.getLog().getId(),
+                    logImage.getEmotions().stream()
+                            .map(emotion -> new ImageEmotionDTO(
+                                    emotion.getMember().getNickname(),
+                                    emotion.getEmotion()
+                            ))
+                            .toList()
+            );
+        }
     }
 
     public record ImageName(

--- a/src/main/java/com/macrosoft/modakserver/domain/image/dto/ImageResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/dto/ImageResponse.java
@@ -15,6 +15,11 @@ public class ImageResponse {
             List<ImageEmotionDTO> emotions) {
     }
 
+    public record ImageName(
+            @Schema(description = "이미지 이름", example = "/dev/772b94e6-2081-4d1d-b331-20015cc287e0.jpeg")
+            String imageName) {
+    }
+
     public record ImageEmotionDTO(
             @Schema(description = "멤버 이름", example = "음침한 윤겸핑")
             String memberNickname,

--- a/src/main/java/com/macrosoft/modakserver/domain/image/entity/LogImage.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/entity/LogImage.java
@@ -36,9 +36,9 @@ public class LogImage extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    private Double latitude;
+    private double latitude;
 
-    private Double longitude;
+    private double longitude;
 
     @Column(nullable = false)
     private LocalDateTime takenAt;

--- a/src/main/java/com/macrosoft/modakserver/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/exception/ImageErrorCode.java
@@ -17,7 +17,10 @@ public enum ImageErrorCode implements ErrorCodeInterface {
     PUT_OBJECT_EXCEPTION("I005", "이미지를 S3에 저장하는 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     IO_EXCEPTION_ON_IMAGE_DELETE("I006", "S3에서 이미지를 삭제하는 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     MALFORMED_URL_EXCEPTION("I007", "이미지 주소 형식이 잘못되었습니다.", HttpStatus.BAD_REQUEST),
-    UNSUPPORTED_ENCODING_EXCEPTION("I008", "이미지 주소의 인코딩 방식이 지원되지 않습니다.", HttpStatus.BAD_REQUEST);
+    UNSUPPORTED_ENCODING_EXCEPTION("I008", "이미지 주소의 인코딩 방식이 지원되지 않습니다.", HttpStatus.BAD_REQUEST),
+    LOG_IMAGE_NOT_FOUND("I009", "해당 이미지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    LOG_IMAGE_NOT_IN_CAMPFIRE("I010", "해당 이미지는 해당 모닥불에 속해 있지 않습니다.", HttpStatus.BAD_REQUEST),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/macrosoft/modakserver/domain/image/repository/LogImageRepository.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/repository/LogImageRepository.java
@@ -1,7 +1,11 @@
 package com.macrosoft.modakserver.domain.image.repository;
 
 import com.macrosoft.modakserver.domain.image.entity.LogImage;
+import com.macrosoft.modakserver.domain.log.entity.Log;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LogImageRepository extends JpaRepository<LogImage, Long> {
+    Page<LogImage> findAllByLog(Log log, Pageable pageable);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/service/ImageService.java
@@ -1,10 +1,13 @@
 package com.macrosoft.modakserver.domain.image.service;
 
 import com.macrosoft.modakserver.domain.image.dto.ImageResponse;
+import com.macrosoft.modakserver.domain.member.entity.Member;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ImageService {
     ImageResponse.ImageUrl uploadImage(MultipartFile image);
 
     void deleteImageFromS3(String imageUrl);
+
+    ImageResponse.ImageDTO getImageDetail(Member member, int campfirePin, Long imageId);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/service/ImageService.java
@@ -9,5 +9,5 @@ public interface ImageService {
 
     void deleteImageFromS3(String imageUrl);
 
-    ImageResponse.ImageDTO getImageDetail(Member member, int campfirePin, Long imageId);
+    ImageResponse.ImageDetail getImageDetail(Member member, int campfirePin, Long imageId);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/image/service/ImageServiceImpl.java
@@ -1,7 +1,9 @@
 package com.macrosoft.modakserver.domain.image.service;
 
 import com.macrosoft.modakserver.domain.image.component.S3ImageComponent;
+import com.macrosoft.modakserver.domain.image.dto.ImageResponse.ImageDTO;
 import com.macrosoft.modakserver.domain.image.dto.ImageResponse.ImageUrl;
+import com.macrosoft.modakserver.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,5 +22,10 @@ public class ImageServiceImpl implements ImageService {
     @Override
     public void deleteImageFromS3(String imageUrl) {
         s3ImageComponent.deleteImageFromS3(imageUrl);
+    }
+
+    @Override
+    public ImageDTO getImageDetail(Member member, int campfirePin, Long imageId) {
+        return null;
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/log/controller/LogController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/controller/LogController.java
@@ -50,14 +50,14 @@ public class LogController {
 
     @Operation(summary = "모닥불 장작 미리보기 가져오기", description = "모닥불에 업로드 되어 있는 장작들의 미리보기 정보를 가져옵니다. 페이지네이션을 지원합니다. `CampfireLogPile` 화면 에서 사용됩니다.")
     @GetMapping(API_CAMPFIRES_LOG)
-    public BaseResponse<LogResponse.LogOverviews> getLogs(
+    public BaseResponse<LogResponse.LogOverviews> getLogOverviews(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "모닥불 핀 번호", example = "111111")
             @PathVariable("campfirePin") int campfirePin,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
     ) {
-        return BaseResponse.onSuccess(logService.getLogs(userDetails.getMember(), campfirePin, page, size));
+        return BaseResponse.onSuccess(logService.getLogOverviews(userDetails.getMember(), campfirePin, page, size));
     }
 
 //    @Operation(summary = "장작의 이미지들 가져오기", description = "장작에 업로드 되어 있는 사진들의 정보를 모두 가져옵니다. 페이지네이션을 지원합니다 (기본 사이즈: 21). `LogDetail` 화면에서 사용됩니다.")
@@ -78,9 +78,9 @@ public class LogController {
 //            @AuthenticationPrincipal CustomUserDetails userDetails,
 //            @Parameter(description = "모닥불 핀 번호", example = "000000")
 //            @PathVariable("campfirePin") int campfirePin
-//            @RequestBody CampfireRequest.Logs logs
+//            @RequestBody CampfireRequest.Logs logOverviews
 //    ) {
-//        return BaseResponse.onSuccess(logService.removeLogs(userDetails.getMember(), campfirePin, logs));
+//        return BaseResponse.onSuccess(logService.removeLogs(userDetails.getMember(), campfirePin, logOverviews));
 //        return null;
 //    }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/log/controller/LogController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/controller/LogController.java
@@ -27,7 +27,7 @@ public class LogController {
     public static final String API_CAMPFIRES_LOG = "/{campfirePin}/logs";
     private final LogService logService;
 
-    @Operation(summary = "모닥불의 장작들의 메타데이터 정보 가져오기", description = "모닥불에 업로드 되어 있는 장작들의 메타데이터 (위치, 시간) 정보를 가져옵니다. 클라이언트에서 추천 장작을 선정할 때 사용됩니다.")
+    @Operation(summary = "모닥불의 장작들의 메타데이터 정보 가져오기", description = "모닥불에 업로드 되어 있는 장작들의 메타데이터 (위치, 시간) 정보를 가져옵니다. `SelectMergeLogs` 화면에서 추천 장작을 선정할 때 사용됩니다.")
     @GetMapping(API_CAMPFIRES_LOG + "/metadata")
     public BaseResponse<LogMetadataList> getLogsMetadata(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -37,7 +37,7 @@ public class LogController {
         return BaseResponse.onSuccess(logService.getLogsMetadata(userDetails.getMember(), campfirePin));
     }
 
-    @Operation(summary = "모닥불에 장작 넣기", description = "모닥불에 장작들을 추가합니다.")
+    @Operation(summary = "모닥불에 장작 넣기", description = "모닥불에 장작들을 추가합니다. `SelectMergeLogs` 화면에서 사용됩니다.")
     @PostMapping(API_CAMPFIRES_LOG)
     public BaseResponse<LogResponse.LogId> addLogs(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -48,7 +48,7 @@ public class LogController {
         return BaseResponse.onSuccess(logService.addLogs(userDetails.getMember(), campfirePin, log));
     }
 
-    @Operation(summary = "모닥불 장작 미리보기 가져오기", description = "모닥불에 업로드 되어 있는 장작들의 미리보기 정보를 가져옵니다. 페이지네이션을 지원합니다. `CampfireLogPile` 화면 에서 사용됩니다.")
+    @Operation(summary = "모닥불의 장작들 미리보기", description = "모닥불에 업로드 되어 있는 장작들의 미리보기 정보를 가져옵니다. 페이지네이션을 지원합니다. `CampfireLogPile` 화면 에서 사용됩니다.")
     @GetMapping(API_CAMPFIRES_LOG)
     public BaseResponse<LogResponse.LogOverviews> getLogOverviews(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -60,17 +60,20 @@ public class LogController {
         return BaseResponse.onSuccess(logService.getLogOverviews(userDetails.getMember(), campfirePin, page, size));
     }
 
-//    @Operation(summary = "장작의 이미지들 가져오기", description = "장작에 업로드 되어 있는 사진들의 정보를 모두 가져옵니다. 페이지네이션을 지원합니다 (기본 사이즈: 21). `LogDetail` 화면에서 사용됩니다.")
-//    @GetMapping(API_CAMPFIRES_LOG + "/{logId}/images")
-//    public BaseResponse<LogResponse.LogDTO> getImages(
-//            @AuthenticationPrincipal CustomUserDetails userDetails,
-//            @Parameter(description = "장작 번호", example = "222222")
-//            @PathVariable("logId") long logId,
-//            @RequestParam(value = "page", defaultValue = "0") int page,
-//            @RequestParam(value = "size", defaultValue = "21") int size
-//    ) {
-//        return BaseResponse.onSuccess(logService.getImages(userDetails.getMember(), campfirePin, logId, page, size));
-//    }
+    @Operation(summary = "장작 상세보기", description = "업로드된 장작에 있는 사진들의 정보를 모두 가져옵니다. 페이지네이션을 지원합니다 (기본 사이즈: 21). `LogDetail` 화면에서 사용됩니다.")
+    @GetMapping(API_CAMPFIRES_LOG + "/{logId}/images")
+    public BaseResponse<LogResponse.LogDetails> getLogDetails(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "모닥불 핀 번호", example = "111111")
+            @PathVariable("campfirePin") int campfirePin,
+            @Parameter(description = "장작 번호", example = "1")
+            @PathVariable("logId") long logId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "21") int size
+    ) {
+        return BaseResponse.onSuccess(
+                logService.getLogDetails(userDetails.getMember(), campfirePin, logId, page, size));
+    }
 
 //    @Operation(summary = "모닥불에 장작 빼기", description = "모닥불에 장작들을 제거합니다.")
 //    @DeleteMapping(API_CAMPFIRES_LOG)

--- a/src/main/java/com/macrosoft/modakserver/domain/log/controller/LogController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/controller/LogController.java
@@ -39,7 +39,7 @@ public class LogController {
 
     @Operation(summary = "모닥불에 장작 넣기", description = "모닥불에 장작들을 추가합니다.")
     @PostMapping(API_CAMPFIRES_LOG)
-    public BaseResponse<LogResponse.LogDTO> addLogs(
+    public BaseResponse<LogResponse.LogId> addLogs(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "모닥불 핀 번호", example = "111111")
             @PathVariable("campfirePin") int campfirePin,
@@ -48,9 +48,9 @@ public class LogController {
         return BaseResponse.onSuccess(logService.addLogs(userDetails.getMember(), campfirePin, log));
     }
 
-    @Operation(summary = "모닥불의 장작들 가져오기", description = "모닥불에 업로드 되어 있는 장작들의 정보를 모두 가져옵니다. 페이지네이션을 지원합니다.")
+    @Operation(summary = "모닥불 장작 미리보기 가져오기", description = "모닥불에 업로드 되어 있는 장작들의 미리보기 정보를 가져옵니다. 페이지네이션을 지원합니다. `CampfireLogPile` 화면 에서 사용됩니다.")
     @GetMapping(API_CAMPFIRES_LOG)
-    public BaseResponse<LogResponse.Logs> getLogs(
+    public BaseResponse<LogResponse.LogOverviews> getLogs(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "모닥불 핀 번호", example = "111111")
             @PathVariable("campfirePin") int campfirePin,
@@ -59,6 +59,18 @@ public class LogController {
     ) {
         return BaseResponse.onSuccess(logService.getLogs(userDetails.getMember(), campfirePin, page, size));
     }
+
+//    @Operation(summary = "장작의 이미지들 가져오기", description = "장작에 업로드 되어 있는 사진들의 정보를 모두 가져옵니다. 페이지네이션을 지원합니다 (기본 사이즈: 21). `LogDetail` 화면에서 사용됩니다.")
+//    @GetMapping(API_CAMPFIRES_LOG + "/{logId}/images")
+//    public BaseResponse<LogResponse.LogDTO> getImages(
+//            @AuthenticationPrincipal CustomUserDetails userDetails,
+//            @Parameter(description = "장작 번호", example = "222222")
+//            @PathVariable("logId") long logId,
+//            @RequestParam(value = "page", defaultValue = "0") int page,
+//            @RequestParam(value = "size", defaultValue = "21") int size
+//    ) {
+//        return BaseResponse.onSuccess(logService.getImages(userDetails.getMember(), campfirePin, logId, page, size));
+//    }
 
 //    @Operation(summary = "모닥불에 장작 빼기", description = "모닥불에 장작들을 제거합니다.")
 //    @DeleteMapping(API_CAMPFIRES_LOG)

--- a/src/main/java/com/macrosoft/modakserver/domain/log/controller/LogController.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/controller/LogController.java
@@ -60,7 +60,7 @@ public class LogController {
         return BaseResponse.onSuccess(logService.getLogOverviews(userDetails.getMember(), campfirePin, page, size));
     }
 
-    @Operation(summary = "장작 상세보기", description = "업로드된 장작에 있는 사진들의 정보를 모두 가져옵니다. 페이지네이션을 지원합니다 (기본 사이즈: 21). `LogDetail` 화면에서 사용됩니다.")
+    @Operation(summary = "장작의 사진들 가져오기", description = "업로드된 장작에 있는 사진들의 아이디와 이름을 가져옵니다. 페이지네이션을 지원합니다 (기본 사이즈: 21). `LogDetail` 화면에서 사용됩니다.")
     @GetMapping(API_CAMPFIRES_LOG + "/{logId}/images")
     public BaseResponse<LogResponse.LogDetails> getLogDetails(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/macrosoft/modakserver/domain/log/dto/LogResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/dto/LogResponse.java
@@ -1,17 +1,9 @@
 package com.macrosoft.modakserver.domain.log.dto;
 
-import com.macrosoft.modakserver.domain.image.dto.ImageResponse;
-import com.macrosoft.modakserver.domain.image.dto.ImageResponse.ImageDTO;
-import com.macrosoft.modakserver.domain.image.dto.ImageResponse.ImageEmotionDTO;
-import com.macrosoft.modakserver.domain.image.entity.Emotion;
-import com.macrosoft.modakserver.domain.image.entity.LogImage;
-import com.macrosoft.modakserver.domain.log.entity.Location;
-import com.macrosoft.modakserver.domain.log.entity.Log;
+import com.macrosoft.modakserver.domain.image.dto.ImageResponse.ImageName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 public class LogResponse {
     public record LogMetadataList(List<LogMetadata> logMetadataList) {
@@ -45,48 +37,22 @@ public class LogResponse {
 
     public record LogOverview(
             @Schema(description = "장작 아이디", example = "1")
-            Long id,
+            Long logId,
             @Schema(description = "장작 사건 시작 시간", example = "2024-11-06T01:41:01.83819")
             LocalDateTime startAt,
             @Schema(description = "장작 주소", example = "포항시 남구")
             String address,
             @Schema(description = "장작 미리보기 사진들, 최대 8장")
-            List<ImageResponse.ImageName> imageNames
+            List<String> imageNames
     ) {
     }
 
-    public record LogDetail(
-            Long id,
-            List<ImageResponse.ImageDTO> Images,
-            LogMetadata logMetadata
+    public record LogDetails(
+            @Schema(description = "장작 아이디", example = "1")
+            Long logId,
+            @Schema(description = "장작 사진 이름과 아이디들")
+            List<ImageName> images,
+            boolean hasNext
     ) {
-        public static LogDetail of(Log log) {
-            Location location = log.getLocation();
-            LogMetadata logMetadata = new LogMetadata(
-                    log.getStartAt(),
-                    log.getEndAt(),
-                    location.getAddress(),
-                    location.getMinLatitude(),
-                    location.getMaxLatitude(),
-                    location.getMinLongitude(),
-                    location.getMaxLongitude()
-            );
-            List<ImageDTO> imageDTOList = makeImageDTOList(log.getLogImages());
-            return new LogDetail(log.getId(), imageDTOList, logMetadata);
-        }
-
-        private static List<ImageDTO> makeImageDTOList(List<LogImage> images) {
-            List<ImageDTO> imageDTOList = new ArrayList<>();
-            for (LogImage image : images) {
-                String imageName = image.getName();
-                List<ImageEmotionDTO> emotionDTOS = new ArrayList<>();
-                Set<Emotion> emotions = image.getEmotions();
-                for (Emotion emotion : emotions) {
-                    emotionDTOS.add(new ImageEmotionDTO(emotion.getMember().getNickname(), emotion.getEmotion()));
-                }
-                imageDTOList.add(new ImageDTO(imageName, emotionDTOS));
-            }
-            return imageDTOList;
-        }
     }
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/log/dto/LogResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/dto/LogResponse.java
@@ -35,15 +35,32 @@ public class LogResponse {
     ) {
     }
 
-    public record Logs(List<LogDTO> logs, boolean hasNext) {
+    public record LogId(Long logId) {
     }
 
-    public record LogDTO(
+    public record LogOverviews(
+            List<LogOverview> logs,
+            boolean hasNext) {
+    }
+
+    public record LogOverview(
+            @Schema(description = "장작 아이디", example = "1")
+            Long id,
+            @Schema(description = "장작 사건 시작 시간", example = "2024-11-06T01:41:01.83819")
+            LocalDateTime startAt,
+            @Schema(description = "장작 주소", example = "포항시 남구")
+            String address,
+            @Schema(description = "장작 미리보기 사진들, 최대 8장")
+            List<ImageResponse.ImageName> imageNames
+    ) {
+    }
+
+    public record LogDetail(
             Long id,
             List<ImageResponse.ImageDTO> Images,
             LogMetadata logMetadata
     ) {
-        public static LogDTO of(Log log) {
+        public static LogDetail of(Log log) {
             Location location = log.getLocation();
             LogMetadata logMetadata = new LogMetadata(
                     log.getStartAt(),
@@ -55,7 +72,7 @@ public class LogResponse {
                     location.getMaxLongitude()
             );
             List<ImageDTO> imageDTOList = makeImageDTOList(log.getLogImages());
-            return new LogDTO(log.getId(), imageDTOList, logMetadata);
+            return new LogDetail(log.getId(), imageDTOList, logMetadata);
         }
 
         private static List<ImageDTO> makeImageDTOList(List<LogImage> images) {

--- a/src/main/java/com/macrosoft/modakserver/domain/log/dto/LogResponse.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/dto/LogResponse.java
@@ -39,7 +39,7 @@ public class LogResponse {
     }
 
     public record LogOverviews(
-            List<LogOverview> logs,
+            List<LogOverview> logOverviews,
             boolean hasNext) {
     }
 

--- a/src/main/java/com/macrosoft/modakserver/domain/log/entity/Location.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/entity/Location.java
@@ -22,16 +22,12 @@ public class Location extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private Double minLatitude;
 
-    @Column(nullable = false)
     private Double maxLatitude;
 
-    @Column(nullable = false)
     private Double minLongitude;
 
-    @Column(nullable = false)
     private Double maxLongitude;
 
     @Setter

--- a/src/main/java/com/macrosoft/modakserver/domain/log/exception/LogErrorCode.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/exception/LogErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum LogErrorCode implements ErrorCodeInterface {
     LOG_NOT_FOUND("L001", "존재하지 않는 장작입니다.", HttpStatus.NOT_FOUND),
-    LOGS_EMPTY("L002", "장작 계산중에 장작이 없는 오류가 발생했습니다.", HttpStatus.NOT_FOUND),
+    LOG_CAMPFIRE_NOT_MATCH("L002", "장작과 캠프파이어가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    LOGS_EMPTY("L003", "장작 계산중에 장작이 없는 오류가 발생했습니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String code;

--- a/src/main/java/com/macrosoft/modakserver/domain/log/service/LogService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/service/LogService.java
@@ -8,7 +8,7 @@ import com.macrosoft.modakserver.domain.member.entity.Member;
 public interface LogService {
     LogMetadataList getLogsMetadata(Member member, int campfirePin);
 
-    LogResponse.LogDTO addLogs(Member member, int campfirePin, LogRequest.UploadLog uploadLog);
+    LogResponse.LogId addLogs(Member member, int campfirePin, LogRequest.UploadLog uploadLog);
 
-    LogResponse.Logs getLogs(Member member, int campfirePin, int page, int size);
+    LogResponse.LogOverviews getLogs(Member member, int campfirePin, int page, int size);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/log/service/LogService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/service/LogService.java
@@ -10,5 +10,5 @@ public interface LogService {
 
     LogResponse.LogId addLogs(Member member, int campfirePin, LogRequest.UploadLog uploadLog);
 
-    LogResponse.LogOverviews getLogs(Member member, int campfirePin, int page, int size);
+    LogResponse.LogOverviews getLogOverviews(Member member, int campfirePin, int page, int size);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/log/service/LogService.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/service/LogService.java
@@ -11,4 +11,6 @@ public interface LogService {
     LogResponse.LogId addLogs(Member member, int campfirePin, LogRequest.UploadLog uploadLog);
 
     LogResponse.LogOverviews getLogOverviews(Member member, int campfirePin, int page, int size);
+
+    LogResponse.LogDetails getLogDetails(Member member, int campfirePin, Long logId, int page, int size);
 }

--- a/src/main/java/com/macrosoft/modakserver/domain/log/service/LogServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/domain/log/service/LogServiceImpl.java
@@ -176,7 +176,7 @@ public class LogServiceImpl implements LogService {
     }
 
     @Override
-    public LogResponse.LogOverviews getLogs(Member member, int campfirePin, int page, int size) {
+    public LogResponse.LogOverviews getLogOverviews(Member member, int campfirePin, int page, int size) {
         Member memberInDB = memberService.getMemberInDB(member);
         Campfire campfire = campfireService.findCampfireByPin(campfirePin);
         campfireService.validateMemberInCampfire(memberInDB, campfire);

--- a/src/main/java/com/macrosoft/modakserver/test/service/TestServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/test/service/TestServiceImpl.java
@@ -41,6 +41,15 @@ public class TestServiceImpl implements TestService {
     private final LogService logService;
     private final EntityManager entityManager;
 
+    private static final String IMAGE_PATH_1 = "dev/c90830f0-7e69-41ba-92b5-713ed5253221.jpeg";
+    private static final String IMAGE_PATH_2 = "dev/7e622a14-9cbe-49d8-be87-5ff51e549cc8.jpeg";
+    private static final String IMAGE_PATH_3 = "dev/af1105bf-85bb-4f79-9c9e-4d3062336150.jpeg";
+    private static final String IMAGE_PATH_4 = "dev/9e3bb690-cf83-4258-8ced-f941a648098a.jpg";
+    private static final String IMAGE_PATH_5 = "dev/636e5833-6c5b-4b17-a22f-07c98d7b0935.jpg";
+    private static final String IMAGE_PATH_6 = "dev/30f32344-9c59-4507-a52d-9f9e399c5dfd.jpg";
+    private static final String IMAGE_PATH_7 = "dev/9347176d-b98f-4e9c-af0d-4e46e075c363.jpg";
+    private static final String IMAGE_PATH_8 = "dev/fa4b41a7-8324-4aad-83a6-3f7703f4ed0f.jpg";
+    
     @Override
     public List<Member> get() {
         return memberRepository.findAll();
@@ -70,27 +79,19 @@ public class TestServiceImpl implements TestService {
             entityManager.clear();
             campfire = campfireRepository.findById(campfire.getId())
                     .orElseThrow(() -> new CustomException(CampfireErrorCode.CAMPFIRE_NOT_FOUND_BY_PIN));
-            log.info("updateCampfirePinById: {}", campfire.getId());
-            log.info("실제 PIN: {}", campfire.getPin());
             pin = 111111;
         }
 
         for (int i = 0; i < 4; i++) {
-            log.info("addMockData: {}", i);
             String authorizationCode = String.valueOf(UUID.randomUUID());
             String identityToken = String.valueOf(UUID.randomUUID());
             String encryptedUserIdentifier = String.valueOf(UUID.randomUUID());
             Long newMemberId = authService.login(SocialType.APPLE, authorizationCode, identityToken,
                     encryptedUserIdentifier).memberId();
-            log.info("newMemberId: {}", newMemberId);
             Member newMember = memberRepository.findById(newMemberId)
                     .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
-            log.info("newMember: {}", newMember);
-            log.info("pin: {}, 실제 pin: {}", pin, campfire.getPin());
             campfireService.joinCampfire(newMember, pin, newCampfireName);
-            log.info("joinCampfire: {}", i);
             logService.addLogs(newMember, pin, testUploadLogs.get(i));
-            log.info("addLogs: {}", i);
         }
 
         return new CampfireResponse.CampfireMain(
@@ -116,11 +117,8 @@ public class TestServiceImpl implements TestService {
                             130.5
                     ),
                     List.of(
-                            new ImageInfo(
-                                    "dev/c90830f0-7e69-41ba-92b5-713ed5253221.jpeg",
-                                    35.98, 129.34, LocalDateTime.of(2023, 3, 3, 3, 3, 3)),
-                            new ImageInfo("dev/7e622a14-9cbe-49d8-be87-5ff51e549cc8.jpeg", 36.0, 129.36,
-                                    LocalDateTime.of(2023, 3, 3, 8, 3, 3))
+                            new ImageInfo(IMAGE_PATH_1, 35.98, 129.34, LocalDateTime.of(2023, 3, 3, 3, 3, 3)),
+                            new ImageInfo(IMAGE_PATH_2, 36.0, 129.36, LocalDateTime.of(2023, 3, 3, 8, 3, 3))
                     )
             ),
             new LogRequest.UploadLog(
@@ -134,10 +132,8 @@ public class TestServiceImpl implements TestService {
                             130.5
                     ),
                     List.of(
-                            new ImageInfo("dev/af1105bf-85bb-4f79-9c9e-4d3062336150.jpeg", 36.01, 129.38,
-                                    LocalDateTime.of(2023, 3, 3, 6, 3, 3)),
-                            new ImageInfo("dev/9e3bb690-cf83-4258-8ced-f941a648098a.jpg", 36.02, 129.39,
-                                    LocalDateTime.of(2023, 3, 3, 11, 3, 3))
+                            new ImageInfo(IMAGE_PATH_3, 36.01, 129.38, LocalDateTime.of(2023, 3, 3, 6, 3, 3)),
+                            new ImageInfo(IMAGE_PATH_4, 36.02, 129.39, LocalDateTime.of(2023, 3, 3, 11, 3, 3))
                     )
             ),
             new LogRequest.UploadLog(
@@ -151,10 +147,8 @@ public class TestServiceImpl implements TestService {
                             127.1
                     ),
                     List.of(
-                            new ImageInfo("dev/636e5833-6c5b-4b17-a22f-07c98d7b0935.jpg", 37.53, 127.05,
-                                    LocalDateTime.of(2021, 1, 1, 1, 1, 1)),
-                            new ImageInfo("dev/30f32344-9c59-4507-a52d-9f9e399c5dfd.jpg", 37.54, 127.06,
-                                    LocalDateTime.of(2021, 1, 1, 6, 1, 1))
+                            new ImageInfo(IMAGE_PATH_5, 37.53, 127.05, LocalDateTime.of(2021, 1, 1, 1, 1, 1)),
+                            new ImageInfo(IMAGE_PATH_6, 37.54, 127.06, LocalDateTime.of(2021, 1, 1, 6, 1, 1))
                     )
             ),
             new LogRequest.UploadLog(
@@ -168,10 +162,8 @@ public class TestServiceImpl implements TestService {
                             127.5
                     ),
                     List.of(
-                            new ImageInfo("dev/9347176d-b98f-4e9c-af0d-4e46e075c363.jpg", 36.65, 127.46,
-                                    LocalDateTime.of(2021, 5, 5, 10, 10, 10)),
-                            new ImageInfo("dev/fa4b41a7-8324-4aad-83a6-3f7703f4ed0f.jpg", 36.66, 127.47,
-                                    LocalDateTime.of(2021, 5, 5, 15, 10, 10))
+                            new ImageInfo(IMAGE_PATH_7, 36.65, 127.46, LocalDateTime.of(2021, 5, 5, 10, 10, 10)),
+                            new ImageInfo(IMAGE_PATH_8, 36.66, 127.47, LocalDateTime.of(2021, 5, 5, 15, 10, 10))
                     )
             )
     );

--- a/src/main/java/com/macrosoft/modakserver/test/service/TestServiceImpl.java
+++ b/src/main/java/com/macrosoft/modakserver/test/service/TestServiceImpl.java
@@ -49,7 +49,7 @@ public class TestServiceImpl implements TestService {
     private static final String IMAGE_PATH_6 = "dev/30f32344-9c59-4507-a52d-9f9e399c5dfd.jpg";
     private static final String IMAGE_PATH_7 = "dev/9347176d-b98f-4e9c-af0d-4e46e075c363.jpg";
     private static final String IMAGE_PATH_8 = "dev/fa4b41a7-8324-4aad-83a6-3f7703f4ed0f.jpg";
-    
+
     @Override
     public List<Member> get() {
         return memberRepository.findAll();
@@ -97,7 +97,7 @@ public class TestServiceImpl implements TestService {
         return new CampfireResponse.CampfireMain(
                 pin,
                 newCampfireName,
-                campfireService.getTodayImage(campfire),
+                campfireService.getTodayImageDTO(campfire),
                 campfire.getMemberCampfires().stream()
                         .map(MemberCampfire::getMember)
                         .map(Member::getId)

--- a/src/test/java/com/macrosoft/modakserver/domain/image/service/ImageServiceImplTest.java
+++ b/src/test/java/com/macrosoft/modakserver/domain/image/service/ImageServiceImplTest.java
@@ -1,0 +1,9 @@
+package com.macrosoft.modakserver.domain.image.service;
+
+class ImageServiceImplTest {
+
+    // TODO: 이미지 상세 조회 예외 처리
+    // 1. 모닥불에 속한 멤버 아님
+    // 2. 모닥불에 속한 이미지 아님
+    // 3. 이미지 없음
+}

--- a/src/test/java/com/macrosoft/modakserver/domain/log/service/LogServiceTest.java
+++ b/src/test/java/com/macrosoft/modakserver/domain/log/service/LogServiceTest.java
@@ -10,6 +10,8 @@ import com.macrosoft.modakserver.domain.log.dto.LogRequest;
 import com.macrosoft.modakserver.domain.log.dto.LogRequest.ImageInfo;
 import com.macrosoft.modakserver.domain.log.dto.LogRequest.UploadLog;
 import com.macrosoft.modakserver.domain.log.dto.LogResponse;
+import com.macrosoft.modakserver.domain.log.dto.LogResponse.LogDetail;
+import com.macrosoft.modakserver.domain.log.dto.LogResponse.LogOverviews;
 import com.macrosoft.modakserver.domain.log.entity.Log;
 import com.macrosoft.modakserver.domain.log.repository.LogRepository;
 import com.macrosoft.modakserver.domain.member.entity.Member;
@@ -139,7 +141,7 @@ class LogServiceTest {
     }
 
     @Nested
-    class AddLogsTests {
+    class AddLogOverviewsTests {
         @Test
         void 장작을_업로드한다_Log_엔티티_검사() {
             // given
@@ -148,10 +150,10 @@ class LogServiceTest {
             int campfirePin = campfireService.createCampfire(member0, campfireName).campfirePin();
 
             // when
-            LogResponse.LogDTO logs = logService.addLogs(member0, campfirePin, uploadLog);
+            LogResponse.LogId logId = logService.addLogs(member0, campfirePin, uploadLog);
 
             // then
-            Log logsInDB = logRepository.findById(logs.id()).orElseThrow();
+            Log logsInDB = logRepository.findById(logId.logId()).orElseThrow();
             List<String> imageNames = logsInDB.getLogImages().stream().map(LogImage::getName).toList();
             assertThat(imageNames).isEqualTo(
                     uploadLog.imageInfos().stream().map(ImageInfo::imageName).toList());
@@ -164,29 +166,6 @@ class LogServiceTest {
             assertThat(logsInDB.getLocation().getMaxLongitude()).isEqualTo(uploadLog.logMetadata().maxLongitude());
             assertThat(logsInDB.getCampfire().getPin()).isEqualTo(campfirePin);
             assertThat(logsInDB.getCampfire().getName()).isEqualTo(campfireName);
-        }
-
-        @Test
-        void 장작을_업로드_한다_LogDTO_검사() {
-            // given
-            UploadLog uploadLog = uploadLogList.get(0);
-            String campfireName = "모닥불";
-            int campfirePin = campfireService.createCampfire(member0, campfireName).campfirePin();
-
-            // when
-            LogResponse.LogDTO logDTO = logService.addLogs(member0, campfirePin, uploadLog);
-
-            // then
-            assertThat(logDTO.logMetadata().endAt()).isEqualTo(uploadLog.logMetadata().endAt());
-            assertThat(logDTO.logMetadata().startAt()).isEqualTo(uploadLog.logMetadata().startAt());
-            assertThat(logDTO.logMetadata().address()).isEqualTo(uploadLog.logMetadata().address());
-            assertThat(logDTO.logMetadata().minLatitude()).isEqualTo(uploadLog.logMetadata().minLatitude());
-            assertThat(logDTO.logMetadata().maxLatitude()).isEqualTo(uploadLog.logMetadata().maxLatitude());
-            assertThat(logDTO.logMetadata().minLongitude()).isEqualTo(uploadLog.logMetadata().minLongitude());
-            assertThat(logDTO.logMetadata().maxLongitude()).isEqualTo(uploadLog.logMetadata().maxLongitude());
-            assertThat(logDTO.Images().size()).isEqualTo(uploadLog.imageInfos().size());
-            assertThat(logDTO.Images().get(0).name()).isEqualTo(uploadLog.imageInfos().get(0).imageName());
-            assertThat(logDTO.Images().get(1).name()).isEqualTo(uploadLog.imageInfos().get(1).imageName());
         }
 
         @Test
@@ -226,7 +205,7 @@ class LogServiceTest {
             campfireService.joinCampfire(member1, campfirePin, campfireName);
 
             // when
-            LogResponse.LogDTO log = logService.addLogs(member1, campfirePin, uploadLog1);
+            logService.addLogs(member1, campfirePin, uploadLog1);
 
             // then
             List<Log> logsInDB = logRepository.findAllByCampfirePin(campfirePin);
@@ -261,7 +240,7 @@ class LogServiceTest {
             campfireService.joinCampfire(member1, campfirePin, campfireName);
 
             // when
-            LogResponse.LogDTO log = logService.addLogs(member1, campfirePin, uploadLog1);
+            logService.addLogs(member1, campfirePin, uploadLog1);
 
             // then
             List<Log> logsInDB = logRepository.findAllByCampfirePin(campfirePin);
@@ -344,7 +323,7 @@ class LogServiceTest {
     }
 
     @Nested
-    class GetLogsMetadataTest {
+    class GetLogOverviewsMetadataTest {
         @Test
         void 멤버가_모닥불에_없을_때_메타데이터를_가져오려고_하면_예외_발생() {
             // given
@@ -385,7 +364,7 @@ class LogServiceTest {
     }
 
     @Nested
-    class GetLogsTests {
+    class GetLogOverviewsTests {
         @Test
         void 멤버가_모닥불에_없을_때_장작을_가져오려고_하면_예외_발생() {
             // given
@@ -409,18 +388,18 @@ class LogServiceTest {
             logService.addLogs(member0, campfirePin, uploadLog2);
 
             // when
-            LogResponse.Logs logs = logService.getLogs(member0, campfirePin, 0, 10);
+            LogOverviews logOverviews = logService.getLogs(member0, campfirePin, 0, 10);
 
             // then
-            assertThat(logs.logs().size()).isEqualTo(2);
+            assertThat(logOverviews.logs().size()).isEqualTo(2);
 
-            LogResponse.LogDTO log0 = logs.logs().get(0);
+            LogDetail log0 = logOverviews.logs().get(0);
             assertThat(log0.logMetadata().startAt()).isEqualTo(uploadLog2.logMetadata().startAt());
             assertThat(log0.logMetadata().endAt()).isEqualTo(uploadLog2.logMetadata().endAt());
             assertThat(log0.logMetadata().address()).isEqualTo(uploadLog2.logMetadata().address());
             assertThat(log0.Images().get(0).name()).isEqualTo(uploadLog2.imageInfos().get(0).imageName());
 
-            LogResponse.LogDTO log1 = logs.logs().get(1);
+            LogDetail log1 = logOverviews.logs().get(1);
             assertThat(log1.logMetadata().startAt()).isEqualTo(uploadLog0.logMetadata().startAt());
             assertThat(log1.logMetadata().endAt()).isEqualTo(uploadLog0.logMetadata().endAt());
             assertThat(log1.logMetadata().address()).isEqualTo(uploadLog0.logMetadata().address());
@@ -438,17 +417,17 @@ class LogServiceTest {
             logService.addLogs(member0, campfirePin, uploadLog2);
 
             // when
-            LogResponse.Logs logs1 = logService.getLogs(member0, campfirePin, 0, 1);
-            LogResponse.Logs logs2 = logService.getLogs(member0, campfirePin, 1, 1);
-            LogResponse.Logs logs3 = logService.getLogs(member0, campfirePin, 2, 1);
+            LogOverviews logOverviews1 = logService.getLogs(member0, campfirePin, 0, 1);
+            LogOverviews logOverviews2 = logService.getLogs(member0, campfirePin, 1, 1);
+            LogOverviews logOverviews3 = logService.getLogs(member0, campfirePin, 2, 1);
 
             // then
-            assertThat(logs1.logs().size()).isEqualTo(1);
-            assertThat(logs1.hasNext()).isTrue();
-            assertThat(logs2.logs().size()).isEqualTo(1);
-            assertThat(logs2.hasNext()).isFalse();
-            assertThat(logs3.logs().size()).isEqualTo(0);
-            assertThat(logs3.hasNext()).isFalse();
+            assertThat(logOverviews1.logs().size()).isEqualTo(1);
+            assertThat(logOverviews1.hasNext()).isTrue();
+            assertThat(logOverviews2.logs().size()).isEqualTo(1);
+            assertThat(logOverviews2.hasNext()).isFalse();
+            assertThat(logOverviews3.logs().size()).isEqualTo(0);
+            assertThat(logOverviews3.hasNext()).isFalse();
         }
     }
 }

--- a/src/test/java/com/macrosoft/modakserver/domain/log/service/LogServiceTest.java
+++ b/src/test/java/com/macrosoft/modakserver/domain/log/service/LogServiceTest.java
@@ -10,7 +10,7 @@ import com.macrosoft.modakserver.domain.log.dto.LogRequest;
 import com.macrosoft.modakserver.domain.log.dto.LogRequest.ImageInfo;
 import com.macrosoft.modakserver.domain.log.dto.LogRequest.UploadLog;
 import com.macrosoft.modakserver.domain.log.dto.LogResponse;
-import com.macrosoft.modakserver.domain.log.dto.LogResponse.LogDetail;
+import com.macrosoft.modakserver.domain.log.dto.LogResponse.LogOverview;
 import com.macrosoft.modakserver.domain.log.dto.LogResponse.LogOverviews;
 import com.macrosoft.modakserver.domain.log.entity.Log;
 import com.macrosoft.modakserver.domain.log.repository.LogRepository;
@@ -374,7 +374,7 @@ class LogServiceTest {
 
             // when then
             assertThatThrownBy(
-                    () -> logService.getLogs(member0, campfirePin, 0, 10));
+                    () -> logService.getLogOverviews(member0, campfirePin, 0, 10));
         }
 
         @Test
@@ -388,22 +388,12 @@ class LogServiceTest {
             logService.addLogs(member0, campfirePin, uploadLog2);
 
             // when
-            LogOverviews logOverviews = logService.getLogs(member0, campfirePin, 0, 10);
+            LogOverviews logOverviews = logService.getLogOverviews(member0, campfirePin, 0, 10);
 
             // then
-            assertThat(logOverviews.logs().size()).isEqualTo(2);
-
-            LogDetail log0 = logOverviews.logs().get(0);
-            assertThat(log0.logMetadata().startAt()).isEqualTo(uploadLog2.logMetadata().startAt());
-            assertThat(log0.logMetadata().endAt()).isEqualTo(uploadLog2.logMetadata().endAt());
-            assertThat(log0.logMetadata().address()).isEqualTo(uploadLog2.logMetadata().address());
-            assertThat(log0.Images().get(0).name()).isEqualTo(uploadLog2.imageInfos().get(0).imageName());
-
-            LogDetail log1 = logOverviews.logs().get(1);
-            assertThat(log1.logMetadata().startAt()).isEqualTo(uploadLog0.logMetadata().startAt());
-            assertThat(log1.logMetadata().endAt()).isEqualTo(uploadLog0.logMetadata().endAt());
-            assertThat(log1.logMetadata().address()).isEqualTo(uploadLog0.logMetadata().address());
-            assertThat(log1.Images().get(0).name()).isEqualTo(uploadLog0.imageInfos().get(0).imageName());
+            LogOverview log0 = logOverviews.logOverviews().get(0);
+            LogOverview log1 = logOverviews.logOverviews().get(1);
+            assertThat(log0.startAt()).isAfter(log1.startAt());
         }
 
         @Test
@@ -417,16 +407,16 @@ class LogServiceTest {
             logService.addLogs(member0, campfirePin, uploadLog2);
 
             // when
-            LogOverviews logOverviews1 = logService.getLogs(member0, campfirePin, 0, 1);
-            LogOverviews logOverviews2 = logService.getLogs(member0, campfirePin, 1, 1);
-            LogOverviews logOverviews3 = logService.getLogs(member0, campfirePin, 2, 1);
+            LogOverviews logOverviews1 = logService.getLogOverviews(member0, campfirePin, 0, 1);
+            LogOverviews logOverviews2 = logService.getLogOverviews(member0, campfirePin, 1, 1);
+            LogOverviews logOverviews3 = logService.getLogOverviews(member0, campfirePin, 2, 1);
 
             // then
-            assertThat(logOverviews1.logs().size()).isEqualTo(1);
+            assertThat(logOverviews1.logOverviews().size()).isEqualTo(1);
             assertThat(logOverviews1.hasNext()).isTrue();
-            assertThat(logOverviews2.logs().size()).isEqualTo(1);
+            assertThat(logOverviews2.logOverviews().size()).isEqualTo(1);
             assertThat(logOverviews2.hasNext()).isFalse();
-            assertThat(logOverviews3.logs().size()).isEqualTo(0);
+            assertThat(logOverviews3.logOverviews().size()).isEqualTo(0);
             assertThat(logOverviews3.hasNext()).isFalse();
         }
     }


### PR DESCRIPTION
<!-- 제목 예시 -->
<!-- [FEAT/#6] 설명 -->
## 📝 작업 내용

-  장작의 위치 정보가 없을 수 있음
-  장작 디테일 뷰 에서 따로 API 주기 + 전체 장작 뷰에서는 장작당 이미지 최대 8개만 주기
-  오늘의 장작 시간 UTC+9에 맞게 조정
- 장작 메인 화면 오늘의 이미지 이미지 아이디 줌

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
### 설명

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성하거나 커멘트로 남겨주세요
 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
